### PR TITLE
docs: k×s coupling guide updates (adaptive + oversampled PSF compose)

### DIFF
--- a/scripts/guides/advanced/over_sampling.py
+++ b/scripts/guides/advanced/over_sampling.py
@@ -527,11 +527,22 @@ Fits then work across every model surface: standard light profiles, linear light
 profiles (which are added at image resolution unblurred, by definition) and pixelized source reconstructions.
 Simulation is supported too — see the `__Oversampled PSF__` section of `scripts/imaging/simulator.py`.
 
+__Adaptive Evaluation: the k x s Coupling__
+
+Adaptive over sampling composes with oversampled convolution: every `over_sample_size` entry must be
+*divisible* by `convolve_over_sample_size` (not equal to it). Each pixel is evaluated on its own adaptive
+sub-grid of size k * s, the values are partially binned to a uniform image at the convolution resolution s,
+convolved, and binned to image resolution — adaptive sampling does the integration accuracy, the uniform
+intermediate does the convolution. The adaptive radial schemes above therefore work unchanged with an
+oversampled PSF, provided their sizes are multiples of s (e.g. [32, 8, 2] with s=2). A non-divisible
+combination raises a clear error. This holds for pixelized sources too, where the coupling is exact by
+linearity of the mapping matrix.
+
 __Limitations__
 
 The following are not supported with an oversampled PSF and raise a clear error if combined with it:
 
- - Adaptive (non-uniform) over sampling, as above.
+ - Over sampling sizes not divisible by `convolve_over_sample_size` (e.g. 3 with s=2).
  - The sparse linear-algebra formalism (`apply_sparse_operator`), whose PSF products are precomputed at image
    resolution.
  - The fixed-linear-function preload (`data_linear_func_matrix`) used to accelerate some fixed-MGE fits.

--- a/scripts/imaging/simulator.py
+++ b/scripts/imaging/simulator.py
@@ -404,8 +404,10 @@ resolution.
 
 Two requirements to be aware of:
 
- - The grid's `over_sample_size` must be uniform and equal to `convolve_over_sample_size` (adaptive over sampling
-   cannot be combined with oversampled convolution, and the code raises a clear error if you try).
+ - Every entry of the grid's `over_sample_size` must be divisible by `convolve_over_sample_size` (the k x s
+   coupling: adaptive evaluation is partially binned to the convolution resolution before blurring, so the
+   adaptive radial schemes above compose with an oversampled PSF; a non-divisible combination raises a clear
+   error).
  - When you later fit data simulated this way, pass the same fine-resolution PSF and the matching
    `convolve_over_sample_size_lp` / `convolve_over_sample_size_pixelization` to the `Imaging` object.
 


### PR DESCRIPTION
Phase-4 docs leg of the k×s coupling (PyAutoLabs/PyAutoArray#362): the over-sampling guide and simulator start-here section update from the uniform-equal rule to divisibility, with the pixelized exactness note. **Merge after** PyAutoArray#363 → PyAutoGalaxy#486 (library-first gate; this prose describes their behaviour). The executed-simulator flip is parked as a batched question on the issue — survey found 76 loaders of the start-here dataset / 127 `from_fits` call sites, which makes the saved-PSF-resolution fork a human decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)