### PR TITLE
feat: visible convolve_over_sample_size input (default 1) — flagship scripts

### DIFF
--- a/scripts/imaging/fit.py
+++ b/scripts/imaging/fit.py
@@ -79,7 +79,16 @@ if al.util.dataset.should_simulate(str(dataset_path)):
         check=True,
     )
 
+# PSF convolution runs at the image resolution (sub size 1), which is the fastest
+# option and accurate for well-sampled PSFs. Supplying a PSF at a multiple of the
+# image resolution and raising this value improves blurring fidelity for
+# undersampled PSFs (e.g. HST / Euclid VIS) at extra compute cost — see
+# `guides/advanced/over_sampling.py` and the simulator's `__Oversampled PSF__` section.
+psf_convolve_over_sample_size = 1
+
 dataset = al.Imaging.from_fits(
+    convolve_over_sample_size_lp=psf_convolve_over_sample_size,
+    convolve_over_sample_size_pixelization=psf_convolve_over_sample_size,
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/imaging/likelihood_function.py
+++ b/scripts/imaging/likelihood_function.py
@@ -72,7 +72,16 @@ if not dataset_path.exists():
         check=True,
     )
 
+# PSF convolution runs at the image resolution (sub size 1), which is the fastest
+# option and accurate for well-sampled PSFs. Supplying a PSF at a multiple of the
+# image resolution and raising this value improves blurring fidelity for
+# undersampled PSFs (e.g. HST / Euclid VIS) at extra compute cost — see
+# `guides/advanced/over_sampling.py` and the simulator's `__Oversampled PSF__` section.
+psf_convolve_over_sample_size = 1
+
 dataset = al.Imaging.from_fits(
+    convolve_over_sample_size_lp=psf_convolve_over_sample_size,
+    convolve_over_sample_size_pixelization=psf_convolve_over_sample_size,
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/imaging/modeling.py
+++ b/scripts/imaging/modeling.py
@@ -102,7 +102,16 @@ if al.util.dataset.should_simulate(str(dataset_path)):
         check=True,
     )
 
+# PSF convolution runs at the image resolution (sub size 1), which is the fastest
+# option and accurate for well-sampled PSFs. Supplying a PSF at a multiple of the
+# image resolution and raising this value improves blurring fidelity for
+# undersampled PSFs (e.g. HST / Euclid VIS) at extra compute cost — see
+# `guides/advanced/over_sampling.py` and the simulator's `__Oversampled PSF__` section.
+psf_convolve_over_sample_size = 1
+
 dataset = al.Imaging.from_fits(
+    convolve_over_sample_size_lp=psf_convolve_over_sample_size,
+    convolve_over_sample_size_pixelization=psf_convolve_over_sample_size,
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/imaging/simulator.py
+++ b/scripts/imaging/simulator.py
@@ -133,7 +133,15 @@ this blurring of the image.
 In this example, use a simple 2D Gaussian PSF, which is convolved with the image of the lens and source galaxies 
 when simulating the dataset.
 """
+# PSF convolution runs at the image resolution (sub size 1), which is the fastest
+# option and accurate for well-sampled PSFs. Supplying a PSF at a multiple of the
+# image resolution and raising this value improves blurring fidelity for
+# undersampled PSFs (e.g. HST / Euclid VIS) at extra compute cost — see
+# `guides/advanced/over_sampling.py` and the simulator's `__Oversampled PSF__` section.
+psf_convolve_over_sample_size = 1
+
 psf = al.Convolver.from_gaussian(
+    convolve_over_sample_size=psf_convolve_over_sample_size,
     shape_native=(11, 11), sigma=0.1, pixel_scales=grid.pixel_scales
 )
 

--- a/scripts/imaging/start_here.py
+++ b/scripts/imaging/start_here.py
@@ -110,7 +110,16 @@ correctly for your data.
 dataset_name = "cosmos_web_ring"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+# PSF convolution runs at the image resolution (sub size 1), which is the fastest
+# option and accurate for well-sampled PSFs. Supplying a PSF at a multiple of the
+# image resolution and raising this value improves blurring fidelity for
+# undersampled PSFs (e.g. HST / Euclid VIS) at extra compute cost — see
+# `guides/advanced/over_sampling.py` and the simulator's `__Oversampled PSF__` section.
+psf_convolve_over_sample_size = 1
+
 dataset = al.Imaging.from_fits(
+    convolve_over_sample_size_lp=psf_convolve_over_sample_size,
+    convolve_over_sample_size_pixelization=psf_convolve_over_sample_size,
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",
     noise_map_path=dataset_path / "noise_map.fits",


### PR DESCRIPTION
Implements the flagship scope of `oversampled_psf_visible_input.md` (PyAutoLabs/autolens_workspace#242): `psf_convolve_over_sample_size = 1` as an explicit documented input in the imaging flagship chain (`start_here`, `modeling`, `fit`, `likelihood_function` loaders + the simulator's `from_gaussian`), short when-to-raise-it prose pointing at the over-sampling guide. **Zero behaviour change** (value 1 everywhere, s=1 path byte-identical, no dataset regeneration). fit/likelihood_function/simulator run clean; start_here/modeling compile (full-search scripts).

**Parallel-claim note:** shares only the *generated* catalogue files with the in-flight `weak-modeling` branch (script sets fully disjoint, verified); whichever merges second re-runs `regenerate_navigator.py autolens`.

**Batched question at sign-off (on the issue):** the wider ~76-script kwarg-with-one-line-comment pass — do it as a follow-up mechanical PR, or fold into the full-adoption prompt (a)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)