### PR TITLE
PyAutoScientist 3b-2: Smoke Tests → thin caller (parity proof)

### DIFF
--- a/.github/scripts/smoke_install.sh
+++ b/.github/scripts/smoke_install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Workspace-owned install epilogue for the reusable Smoke Tests workflow
+# (PyAutoHeart/.github/workflows/smoke-tests.yml). Runs with cwd at the
+# checkout root (the dependency chain is cloned beside `workspace/`) and
+# receives PYTHON_VERSION. Everything that differs per workspace lives
+# here; the ceremony lives in the reusable workflow.
+set -e
+
+if [ "$PYTHON_VERSION" = "3.12" ]; then
+  pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
+  pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
+else
+  pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
+  pip install numba nufftax
+fi
+pip install tensorflow-probability==0.25.0
+pip install jupyter nbconvert ipynb-py-convert

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -1,107 +1,15 @@
 name: Smoke Tests
 
+# Thin caller for PyAutoHeart's reusable smoke-test workflow. The ceremony
+# (chain checkout, branch matching, runner, Slack) lives centrally; this
+# workspace declares its dependency chain and owns its install epilogue
+# (.github/scripts/smoke_install.sh) and runner (.github/scripts/run_smoke.py).
+
 on: [push, pull_request]
 
 jobs:
   smoke:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.12', '3.13']
-    steps:
-    - name: Checkout PyAutoConf
-      uses: actions/checkout@v4
-      with:
-        repository: PyAutoLabs/PyAutoConf
-        path: PyAutoConf
-    - name: Checkout PyAutoFit
-      uses: actions/checkout@v4
-      with:
-        repository: PyAutoLabs/PyAutoFit
-        path: PyAutoFit
-    - name: Checkout PyAutoArray
-      uses: actions/checkout@v4
-      with:
-        repository: PyAutoLabs/PyAutoArray
-        path: PyAutoArray
-    - name: Checkout PyAutoGalaxy
-      uses: actions/checkout@v4
-      with:
-        repository: PyAutoLabs/PyAutoGalaxy
-        path: PyAutoGalaxy
-    - name: Checkout PyAutoLens
-      uses: actions/checkout@v4
-      with:
-        repository: PyAutoLabs/PyAutoLens
-        path: PyAutoLens
-    - name: Checkout PyAutoBuild
-      uses: actions/checkout@v4
-      with:
-        repository: PyAutoLabs/PyAutoBuild
-        path: PyAutoBuild
-    - name: Checkout workspace
-      uses: actions/checkout@v4
-      with:
-        path: workspace
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Extract branch name
-      id: extract_branch
-      shell: bash
-      run: |
-        cd workspace
-        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
-    - name: Match library branches
-      shell: bash
-      run: |
-        BRANCH="${{ steps.extract_branch.outputs.branch }}"
-        for PKG in PyAutoConf PyAutoFit PyAutoArray PyAutoGalaxy PyAutoLens; do
-          pushd "$PKG"
-          if [[ -n "$(git ls-remote --heads origin "$BRANCH")" ]]; then
-            echo "Branch $BRANCH exists in $PKG — checking out"
-            git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
-          else
-            echo "Branch $BRANCH not in $PKG — staying on main"
-          fi
-          popd
-        done
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip setuptools wheel
-        pip install pyyaml
-        if [ "${{ matrix.python-version }}" = "3.12" ]; then
-          pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
-          pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
-        else
-          pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
-          pip install numba nufftax
-        fi
-        pip install tensorflow-probability==0.25.0
-        pip install jupyter nbconvert ipynb-py-convert
-    - name: Prepare cache dirs
-      run: |
-        mkdir -p /tmp/numba_cache /tmp/matplotlib
-    - name: Run smoke tests
-      env:
-        JAX_ENABLE_X64: "True"
-        NUMBA_CACHE_DIR: /tmp/numba_cache
-        MPLCONFIGDIR: /tmp/matplotlib
-        PYTHONPATH: ${{ github.workspace }}/PyAutoBuild/autobuild
-      run: |
-        cd workspace
-        python .github/scripts/run_smoke.py
-    - name: Slack notify on failure
-      if: ${{ failure() }}
-      uses: slackapi/slack-github-action@v1.21.0
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      with:
-        channel-id: C03S98FEDK2
-        payload: |
-          {
-            "text": "${{ github.repository }}/${{ github.ref_name }} smoke tests (Python ${{ matrix.python-version }}) ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          }
+    uses: PyAutoLabs/PyAutoHeart/.github/workflows/smoke-tests.yml@main
+    with:
+      chain: "PyAutoConf PyAutoFit PyAutoArray PyAutoGalaxy PyAutoLens"
+    secrets: inherit


### PR DESCRIPTION
## Summary
First conversion for Heart#51: the 107-line fat `smoke_tests.yml` becomes a 16-line thin caller of PyAutoHeart's reusable workflow, plus `.github/scripts/smoke_install.sh` carrying this workspace's exact install block verbatim (chain + [optional] on 3.12 / numba+nufftax on 3.13 + tensorflow-probability pin + jupyter tooling). Same workflow name, same matrix, same pip set.

**This PR's own "Smoke Tests" check is the parity proof** — it must run green through the reusable workflow (requires the Heart PR merged first; re-run the check after).

## API Changes
None — CI only; no script or config changes.

## Test Plan
- [ ] "Smoke Tests" check green on this PR via the reusable workflow (both python versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)