### PR TITLE
docs: shared source-mesh sections on the multi feature examples (phase 3/4)

### DIFF
--- a/scripts/multi/features/dataset_offsets/modeling.py
+++ b/scripts/multi/features/dataset_offsets/modeling.py
@@ -22,6 +22,10 @@ To apply the misalignment, the code subtracts the offset from the grids aligned 
 rotates them about the offset point before performing lensing calculations. The light and mass model centres
 do not change; only the coordinates of the image pixels input into these profiles are transformed.
 
+When the source is reconstructed on a pixelization, these per-dataset offsets pair naturally with the shared
+source-mesh feature (`shared_preloads=True`, see `features/same_wavelength/modeling.py`): the shared Delaunay
+mesh is defined in the reference dataset's frame and every offset dataset's grid is traced onto it.
+
 __Contents__
 
 - **Advantages & Disadvantages:** If one fits a lens model to one dataset and applies it to other datasets, it is common to see the.

--- a/scripts/multi/features/imaging_and_interferometer/modeling.py
+++ b/scripts/multi/features/imaging_and_interferometer/modeling.py
@@ -17,6 +17,7 @@ __Contents__
 - **Imaging Masking:** Define a 3.0" circular mask, which includes the emission of the lens and source galaxies.
 - **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
 - **Model:** Compose the lens model fitted to the data.
+- **Shared Source Mesh (Pixelization):** Reconstruct the source of both datasets on one shared Delaunay mesh via `shared_preloads=True`.
 - **Search:** Configure the non-linear search used to fit the model.
 - **Result:** Overview of the results of the model-fit.
 
@@ -212,6 +213,28 @@ The `info` of the model shows us there are two models, one for the imaging datas
 dataset. 
 """
 print(factor_graph.global_prior_model.info)
+
+"""
+__Shared Source Mesh (Pixelization)__
+
+When the source is reconstructed on a pixelization, the imaging and interferometer fits can share one
+source-plane Delaunay mesh by setting `shared_preloads=True` on both analyses (see
+`features/same_wavelength/modeling.py` for the full description):
+
+    analysis_list = [
+        al.AnalysisImaging(dataset=dataset_imaging, adapt_images=adapt_images, shared_preloads=True),
+        al.AnalysisInterferometer(dataset=dataset_interferometer, shared_preloads=True),
+    ]
+
+The shared mesh is source-plane geometry, so it is dataset-type-agnostic: the lead factor (the first analysis
+in the graph that opted in, of either type) ray-traces it once per likelihood evaluation and both datasets map
+their own grids onto it. Every fit consumes only the parts of the shared state that are valid for its dataset
+type — the mesh geometry crosses dataset types, while a curvature matrix or mapper shared between identical
+interferometer channels (the datacube case) never leaks into an imaging fit. Each dataset keeps its own
+reconstruction and its own linear algebra (the imaging fit blurs with its PSF; the interferometer fit works in
+the uv-plane), but the two source reconstructions live on the identical source-pixel grid and are directly
+comparable.
+"""
 
 """
 __Search__

--- a/scripts/multi/features/same_wavelength/modeling.py
+++ b/scripts/multi/features/same_wavelength/modeling.py
@@ -24,6 +24,7 @@ __Contents__
 - **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
 - **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
 - **Model:** Compose the lens model fitted to the data.
+- **Shared Source Mesh (Pixelization):** Reconstruct the source of every exposure on one shared Delaunay mesh via `shared_preloads=True`.
 - **Search:** Configure the non-linear search used to fit the model.
 - **Result:** Overview of the results of the model-fit.
 
@@ -183,6 +184,45 @@ factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
 The `info` of the model shows us there are two models each with linear light profiles.
 """
 print(factor_graph.global_prior_model.info)
+
+"""
+__Shared Source Mesh (Pixelization)__
+
+When the source is reconstructed on a pixelization (see `features/pixelization`), fitting each exposure as an
+independent factor has a subtle drawback: every exposure builds its own source-plane mesh (the image-mesh centres
+are ray-traced independently per dataset), so the per-exposure source reconstructions live on slightly different
+source-pixel grids and cannot be compared pixel-by-pixel.
+
+Because all exposures share one lens model, the source-plane mesh is exposure-invariant. Setting
+`shared_preloads=True` on every `AnalysisImaging` opts the factor graph into the shared-state mechanism: the lead
+factor ray-traces its image-mesh once per likelihood evaluation and every exposure maps its own image grid onto
+that identical shared Delaunay mesh:
+
+    analysis_list = [
+        al.AnalysisImaging(
+            dataset=dataset,
+            adapt_images=adapt_images,  # image-mesh pixelizations (e.g. `Overlay` + `Delaunay`) use adapt images
+            shared_preloads=True,
+        )
+        for dataset in dataset_list
+    ]
+
+Every exposure then reconstructs the source on the same source-pixel grid: the reconstructions are directly
+comparable (their differences diagnose registration errors and PSF quality), and the redundant per-exposure
+image-mesh construction and mesh ray-tracing are skipped. Each exposure still builds its own mapping matrix,
+PSF-blurred mapping matrix, curvature matrix and regularization matrix — these depend on the exposure's own PSF,
+pixel offsets and (for adaptive schemes) data, so they are never shared.
+
+If the exposures have known pixel offsets (e.g. undithered HST exposures), combine this with the per-dataset
+`DatasetModel` offsets shown in `features/dataset_offsets` — the shared mesh is defined in the lead exposure's
+frame and every other exposure's offset grid is traced onto it. Offsets from a data reduction (e.g. differences
+of each frame's `target_pixel` in PyAutoReduce frame products) are best applied as fixed, known offsets; for
+precision applications make the per-exposure (dy, dx) free parameters with Gaussian priors of width equal to the
+measured registration residuals (typically ~0.1-0.3 pixels for HST/JWST).
+
+Note that each exposure still receives its own reconstruction (solved against its own data). A single joint
+reconstruction solved against all exposures simultaneously is a separate, planned feature.
+"""
 
 """
 __Search__

--- a/scripts/multi/features/wavelength_dependence/modeling.py
+++ b/scripts/multi/features/wavelength_dependence/modeling.py
@@ -22,6 +22,7 @@ __Contents__
 - **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
 - **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
 - **Model:** Compose the lens model fitted to the data.
+- **Shared Source Mesh (Pixelization):** Reconstruct every band's source on one shared Delaunay mesh via `shared_preloads=True`.
 - **Search:** Configure the non-linear search used to fit the model.
 - **Result:** Overview of the results of the model-fit.
 
@@ -217,6 +218,25 @@ The factor graph is created and its info can be printed after the relational mod
 factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
 
 print(factor_graph.global_prior_model.info)
+
+"""
+__Shared Source Mesh (Pixelization)__
+
+When the source is reconstructed on a pixelization, every band can reconstruct its source on the identical
+shared Delaunay mesh by setting `shared_preloads=True` on each `AnalysisImaging` (see
+`features/same_wavelength/modeling.py` for the full description):
+
+    analysis_list = [
+        al.AnalysisImaging(dataset=dataset, adapt_images=adapt_images, shared_preloads=True)
+        for dataset in dataset_list
+    ]
+
+Because the lens model is shared, the source-plane mesh is band-invariant and is ray-traced once by the lead
+factor. Each band still solves for its own reconstruction against its own data — exactly what multi-wavelength
+modeling needs, since the source's appearance varies with wavelength (its colour). The shared mesh makes the
+per-band reconstructions directly comparable pixel-by-pixel, which is what turns them into a resolved colour
+map of the source.
+"""
 
 """
 __Search__


### PR DESCRIPTION
## Summary

Phase 3/4 of the multi-dataset shared-state epic (autolens_workspace#260; design PyAutoLens#599; library PyAutoArray#380 + PyAutoLens#600): **docstring'd API sections on the existing `multi/` feature examples** for the shared source-mesh path (`AnalysisImaging(shared_preloads=True)`).

## Scripts Changed
- `scripts/multi/features/same_wavelength/modeling.py` — headline section: per-exposure offsets + one shared Delaunay mesh; honest per-exposure-reconstruction semantics (the literal joint solve is a planned follow-up); PyAutoReduce shift provenance (fixed-by-default, optional free (dy,dx) with residual-width priors).
- `scripts/multi/features/wavelength_dependence/modeling.py` — shared mesh, per-band reconstructions = resolved source colour map.
- `scripts/multi/features/imaging_and_interferometer/modeling.py` — dataset-type-agnostic mesh; lead-factor + scoped-consumption semantics.
- `scripts/multi/features/dataset_offsets/modeling.py` — cross-reference.

Docstring-only (all four compile; no runtime behaviour change). Simulators untouched — shifts stay demonstrated by `dataset_offsets/` (scope call recorded on the issue).

## Autonomy
`--auto` safe (four-leg gate on issue #260; Heart YELLOW reason set unchanged from in-session ack). Merge after the paired library PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
