### PR TITLE
docs: features README points at the shared source-mesh API (phase 4/4)

### DIFF
--- a/scripts/multi/features/README.md
+++ b/scripts/multi/features/README.md
@@ -15,7 +15,7 @@ and interpret the results a lens model fit. A full guide to result analysis is g
 - `dataset_offsets`: Datasets may have small offsets due to pointing errors, which can be accounted for in the model.
 - `imaging_and_interferometer`: Imaging and interferometer datasets are fitted simultaneously.
 - `one_by_one`: Multiple datasets are fitted one-by-one in a sequence.
-- `same_wavelength`: Multiple datasets that are observed at the same wavelength are fitted simultaneously.
+- `same_wavelength`: Multiple datasets that are observed at the same wavelength are fitted simultaneously (includes the shared source-mesh API, `shared_preloads=True`, for reconstructing every exposure on one Delaunay mesh).
 - `wavelength_dependence`: A model is fitted where parameters depend on wavelength following a functional form.
 - `pixelization`: The source is reconstructed using an adaptive Voronoi mesh.
 - `slam`: Using the Source, Light and Mass (SLAM) pipeline to perform lens modeling of multiple datasets simultaneously.


### PR DESCRIPTION
## Summary

Phase 4/4 (final) of the multi-dataset shared-state epic (design PyAutoLens#599): the docs phase, deliberately minimal per workspace docs policy — the features README row points at the shared source-mesh API; the full documentation lives in the example docstring sections shipped in #261 and the library class docstrings (`aa.PreloadsImaging`, `AnalysisImaging.shared_preloads`). No rst entries by precedent (the datacube preloads have none — docstrings are the API reference).

Closes out the epic: phases 1 (design #599), 2 (PyAutoArray#380/PyAutoLens#600), scoped-preloads follow-up (#381/#601), 3 (#261/#162/#60) all merged 2026-07-10.

## Scripts Changed
- `scripts/multi/features/README.md` — one row.

## Autonomy
`--auto` safe continuation (README-only: tests/smoke n/a, review trivial-CLEAN, Heart YELLOW set unchanged from in-session ack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
