### PR TITLE
docs: skip interferometer example when nufftax absent (Python matrix)

### DIFF
--- a/scripts/interferometer/modeling.py
+++ b/scripts/interferometer/modeling.py
@@ -67,6 +67,25 @@ import autolens.plot as aplt
 import numpy as np
 
 """
+__NUFFT Backend Check__
+
+Interferometer analysis uses the default `TransformerNUFFT`, backed by the
+`nufftax` NUFFT library. It ships with the `[optional]` extras and requires
+Python >= 3.12. When it is not installed (e.g. the NumPy-only CI matrix), skip
+this example gracefully rather than erroring on the data-simulation step.
+"""
+import importlib.util
+import sys
+
+if importlib.util.find_spec("nufftax") is None:
+    print(
+        "Skipping interferometer example: the `nufftax` NUFFT backend is not "
+        "installed (install with `pip install autolens[optional]`; requires "
+        "Python >= 3.12)."
+    )
+    sys.exit(0)
+
+"""
 __Mask__
 
 We define the ‘real_space_mask’ which defines the grid the image the strong lens is evaluated using.


### PR DESCRIPTION
## Summary

The PyAutoBuild **Python Version Matrix** installs the NumPy-only stack, so `scripts/interferometer/modeling.py` failed with `ModuleNotFoundError` on the optional **nufftax** NUFFT backend (ships via `[optional]`; requires Python >= 3.12).

Adds an `importlib.util.find_spec("nufftax")` guard near the top that skips the example gracefully (prints a message and `sys.exit(0)`) when nufftax is absent. Under the full release stack the example runs unchanged.

## Verification
Ran against a clean 2026.7.9.1 venv without nufftax: prints the skip message and exits 0 before the data-simulation step.

## Scripts Changed
- `scripts/interferometer/modeling.py` — backend-absent guard only; no behaviour change when nufftax is present. Notebook regenerates from the script on the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
