### PR TITLE
chore: single-source the never-rewrite-history policy (generated block)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,13 +176,28 @@ test with `run_smoke.py`; regenerate notebooks after.
 **PR description:** summarise what changed and why, list the scripts touched, confirm notebooks were
 regenerated, and add a "Could not update" section for any still-failing scripts.
 
-## Clean state
+<!-- repos_sync:history:begin -->
+## Never rewrite history
 
-Never rewrite history on a repo with a remote (no `git init` over a tracked tree, no force-push to
-`main`, no rebasing pushed shared branches). To reset a dirty tree the only correct sequence is:
+NEVER perform these operations on any repo with a remote:
 
-```bash
-git fetch origin
-git reset --hard origin/main
-git clean -fd
-```
+- `git init` in a directory already tracked by git
+- `rm -rf .git && git init`
+- Commit with subject "Initial commit", "Fresh start", "Start fresh", "Reset
+  for AI workflow", or any equivalent message on a branch with a remote
+- `git push --force` to `main` (or any branch tracked as `origin/HEAD`)
+- `git filter-repo` / `git filter-branch` on shared branches
+- `git rebase -i` rewriting commits already pushed to a shared branch
+
+If the working tree needs a clean state, the **only** correct sequence is:
+
+    git fetch origin
+    git reset --hard origin/main
+    git clean -fd
+
+This applies equally to humans, local Claude Code, cloud Claude agents, Codex,
+and any other agent. The "Initial commit — fresh start for AI workflow" pattern
+that appeared independently on origin and local for three workspace repos is
+exactly what this rule prevents — it costs ~40 commits of redundant local work
+every time it happens.
+<!-- repos_sync:history:end -->


### PR DESCRIPTION
Spec 4 of the ecosystem AGENTS.md standardization (`PyAutoMind/z_features/agents_md_standardization.md`). Replaces this repo's hand-maintained history-rewrite guidance with the generated `<!-- repos_sync:history -->` block — byte-identical canonical text, now drift-checked against `PyAutoMind/policy/never_rewrite_history.md`. The safety text stays inline; only the manual copy is retired. Docs-only (AGENTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUGujq6jAgU3CExnLkkELe)_