### PR TITLE
weak: rescale `simple` example to a genuine cluster-scale lens

### DIFF
--- a/scripts/weak/fit.py
+++ b/scripts/weak/fit.py
@@ -34,10 +34,10 @@ import autolens.plot as aplt
 """
 __Dataset__
 
-We load the simulated `WeakDataset` produced by `scripts/weak/simulator.py`: 200 background
-source-galaxy positions in a 3.0" half-extent square, each with a measured `(gamma_2, gamma_1)` shear
-vector and per-galaxy noise standard deviation 0.3. The shear field carries the signature of the
-foreground lens's mass distribution.
+We load the simulated `WeakDataset` produced by `scripts/weak/simulator.py`: 1500 background
+source-galaxy positions in a 50"-200" annulus around a cluster-scale lens, each with a measured
+`(gamma_2, gamma_1)` shear vector and per-galaxy shape noise of 0.25. The shear field carries the
+signature of the foreground lens's mass distribution.
 
 __Dataset Auto-Simulation__
 
@@ -78,15 +78,15 @@ The model `Tracer` is built from the same primitives the simulator used: a foreg
 galaxy and a background source galaxy with no light profile (weak-lensing measurements are sensitive to
 the lens mass, not the source's appearance). In a real workflow the mass parameters would be inferred by a
 non-linear search (see the modeling tutorial in the next step of the weak-lensing series). Here we
-hand-pick parameters close to the simulator's truth — `einstein_radius=1.6`, `axis_ratio=0.9`,
-`angle=45.0`, `centre=(0.0, 0.0)` — so the fit shows what residuals consistent with shape noise look like.
+hand-pick the simulator's truth — `einstein_radius=25.0`, `axis_ratio=0.8`, `angle=45.0`,
+`centre=(0.0, 0.0)` — so the fit shows what residuals consistent with shape noise look like.
 """
 lens_galaxy = al.Galaxy(
     redshift=0.5,
     mass=al.mp.Isothermal(
         centre=(0.0, 0.0),
-        einstein_radius=1.6,
-        ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
+        einstein_radius=25.0,
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=45.0),
     ),
 )
 

--- a/scripts/weak/likelihood_function.py
+++ b/scripts/weak/likelihood_function.py
@@ -43,9 +43,9 @@ import autolens as al
 """
 __Dataset__
 
-We load the simulated `WeakDataset` produced by `scripts/weak/simulator.py`: 200 background source-galaxy
-positions, each with a measured `(gamma_2, gamma_1)` shear vector and a per-galaxy noise standard deviation
-of 0.3 (a typical ground-based shape-noise value).
+We load the simulated `WeakDataset` produced by `scripts/weak/simulator.py`: 1500 background source-galaxy
+positions in a 50"-200" annulus around a cluster-scale lens, each with a measured `(gamma_2, gamma_1)` shear
+vector and a per-galaxy shape noise of 0.25 (a typical weak-lensing shape-noise value).
 
 __Dataset Auto-Simulation__
 
@@ -93,8 +93,8 @@ lens_galaxy = al.Galaxy(
     redshift=0.5,
     mass=al.mp.Isothermal(
         centre=(0.0, 0.0),
-        einstein_radius=1.6,
-        ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
+        einstein_radius=25.0,
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=45.0),
     ),
 )
 
@@ -158,7 +158,7 @@ Step three: the chi-squared is the sum of squared normalized residuals over all 
 $\\chi^2 = \\sum_{i=1}^{N} \\sum_{k=1}^{2} \\left( \\frac{\\gamma^{\\rm data}_{i,k} - \\gamma^{\\rm model}_{i,k}}{\\sigma_i} \\right)^2$
 
 For a well-fitting model whose residuals are pure shape noise, the expected chi-squared is approximately the
-number of data points, `2N = 400` — a quick sanity check worth internalising for any weak-lensing fit.
+number of data points, `2N = 3000` — a quick sanity check worth internalising for any weak-lensing fit.
 """
 chi_squared_map = normalized_residual_map**2.0
 

--- a/scripts/weak/modeling.py
+++ b/scripts/weak/modeling.py
@@ -36,7 +36,7 @@ __Contents__
 
 __Model__
 
-This script fits a `WeakDataset` of a 'galaxy-scale' lens with a model where:
+This script fits a `WeakDataset` of a 'cluster-scale' lens with a model where:
 
  - The lens galaxy's total mass distribution is an `Isothermal` [5 parameters].
 
@@ -59,9 +59,9 @@ import autolens.plot as aplt
 """
 __Dataset__
 
-We load the simulated `WeakDataset` produced by `scripts/weak/simulator.py`: 200 background source-galaxy
-positions in a 3.0" half-extent square, each with a measured `(gamma_2, gamma_1)` shear vector and per-galaxy
-noise standard deviation 0.3.
+We load the simulated `WeakDataset` produced by `scripts/weak/simulator.py`: 1500 background source-galaxy
+positions in a 50"-200" annulus around a cluster-scale lens, each with a measured `(gamma_2, gamma_1)` shear
+vector and per-galaxy shape noise of 0.25.
 
 If the dataset does not already exist on your system, it is created by running the simulator script, so this
 example can be run without manually simulating data first.
@@ -110,10 +110,21 @@ project **PyAutoFit** — the identical API used by every other modeling script 
 Note what is absent compared to `scripts/imaging/modeling.py`: no light profiles, no `ExternalShear` (the
 shear field *is* the data here — an external shear component would be degenerate with the signal at leading
 order for this single-lens dataset) and therefore a much smaller parameter space (N=5 versus N=21+).
+
+__Cluster-Scale Priors__
+
+The default `Isothermal` priors are tuned for galaxy-scale lenses: the Einstein radius is a `UniformPrior`
+over 0"-8" and the centre is a tight `GaussianPrior` of width 0.1". For this cluster the truth (25") lies
+outside that Einstein-radius prior entirely, so we widen both to the cluster scale — a wide Einstein-radius
+prior out to 60" and a 20"-wide centre prior about the field origin. Setting priors to the scale of the
+system being fitted is standard practice; the defaults are simply a galaxy-scale starting point.
 """
 # Lens:
 
 mass = af.Model(al.mp.Isothermal)
+mass.einstein_radius = af.UniformPrior(lower_limit=0.0, upper_limit=60.0)
+mass.centre.centre_0 = af.GaussianPrior(mean=0.0, sigma=20.0)
+mass.centre.centre_1 = af.GaussianPrior(mean=0.0, sigma=20.0)
 
 lens = af.Model(al.Galaxy, redshift=0.5, mass=mass)
 
@@ -179,8 +190,8 @@ analysis = al.AnalysisWeak(dataset=dataset)
 """
 __Run Times__
 
-A single log-likelihood evaluation — one shear-field evaluation at 200 galaxy positions plus a chi-squared
-sum — takes of order a millisecond. Nautilus needs roughly 10,000–30,000 evaluations for this 5-parameter
+A single log-likelihood evaluation — one shear-field evaluation at 1500 galaxy positions plus a chi-squared
+sum — takes of order a few milliseconds. Nautilus needs roughly 10,000–30,000 evaluations for this 5-parameter
 model, so the full fit completes in a few minutes on a single CPU.
 
 This is the key practical difference from imaging fits: the data volume of a shear catalogue is tiny (a few

--- a/scripts/weak/simulator.py
+++ b/scripts/weak/simulator.py
@@ -6,6 +6,11 @@ This script simulates a weak gravitational lensing shear catalogue. Unlike the i
 a 2D image of the lensed source) the weak-lensing simulator produces a *catalogue* of (gamma_2, gamma_1) shear
 measurements at the (y, x) positions of a population of background source galaxies.
 
+The lens is a **cluster-scale** mass (Einstein radius 25", the regime where weak lensing is actually used) and the
+background galaxies are placed in an **annulus outside the strong-lensing core** — this is where real weak-lensing
+measurements are made, so the simulated shears are genuinely weak (|gamma| ~ 0.05-0.2) rather than the order-unity
+shears found among galaxies projected near the Einstein radius.
+
 The shear computation itself comes from `Tracer.shear_yx_2d_via_hessian_from`, which differentiates the
 deflection-angle field. On top of that the simulator adds Gaussian shape noise per galaxy (the dominant noise
 source in real weak-lensing data — each galaxy has a random unlensed ellipticity around 0.2-0.4 per component).
@@ -14,8 +19,8 @@ __Contents__
 
 - **Model:** Compose the lens model the shear field is computed from.
 - **Dataset Paths:** The `dataset_type` and `dataset_name` define the on-disk output folder.
-- **Ray Tracing:** Build a Tracer from an Isothermal lens galaxy.
-- **Source Positions:** Draw a uniform-random distribution of background source galaxy positions.
+- **Ray Tracing:** Build a Tracer from a cluster-scale Isothermal lens galaxy.
+- **Source Positions:** Draw background source galaxies in an annulus outside the strong-lensing core.
 - **Simulator:** Construct a `SimulatorShearYX` with the desired shape-noise level and random seed.
 - **Output:** Save the simulated `WeakDataset` and the `Tracer` to JSON.
 - **Visualize:** Plot the shear field and the dataset subplot mosaic via `aplt`.
@@ -26,6 +31,8 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 # from autoconf import setup_notebook; setup_notebook()
 
 from pathlib import Path
+
+import numpy as np
 
 import autolens as al
 import autolens.plot as aplt
@@ -47,8 +54,11 @@ dataset_path = Path("dataset") / dataset_type / dataset_name
 """
 __Ray Tracing__
 
-We define the lens galaxy's mass distribution as an `Isothermal` profile (no external shear, no source light —
-weak-lensing measurements are sensitive to the shear field induced by the lens mass alone).
+We define the lens galaxy's mass distribution as a **cluster-scale** `Isothermal` profile with an Einstein radius
+of 25" (no external shear, no source light — weak-lensing measurements are sensitive to the shear field induced
+by the lens mass alone). A 25" Einstein radius corresponds to a very massive cluster (velocity dispersion of order
+1200-1400 km/s) — the mass scale on which weak lensing is the tool of choice, because the shear signal extends to
+the many-arc-minute radii where strong lensing has no features.
 
 Because the source-galaxy positions are an irregular catalogue rather than a 2D pixel grid, this simulator
 does not need PSF convolution, over-sampling, or background-sky modelling — those are all imaging-specific
@@ -58,8 +68,8 @@ lens_galaxy = al.Galaxy(
     redshift=0.5,
     mass=al.mp.Isothermal(
         centre=(0.0, 0.0),
-        einstein_radius=1.6,
-        ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
+        einstein_radius=25.0,
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=45.0),
     ),
 )
 
@@ -68,21 +78,50 @@ source_galaxy = al.Galaxy(redshift=1.0)
 tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
 
 """
+__Source Positions__
+
+Real weak-lensing measurements avoid the strong-lensing core, where the linear-shear approximation breaks down
+and cluster-member galaxies contaminate the sample. We therefore draw the background galaxies in an **annulus**
+between an inner radius of 50" (~2 Einstein radii, safely into the weak regime) and an outer radius of 200"
+(~3.3 arc-minutes), uniformly in area.
+
+This is the physically genuine weak-lensing geometry: at 50" the shear is |gamma| ~ 0.25 and by 200" it has
+fallen to |gamma| ~ 0.03, so every galaxy is a *weak* probe whose individual shear is well below the 0.25 shape
+noise. The signal lives in the ensemble of 1500 galaxies (a deep-survey source density of ~45 / arc-minute^2),
+exactly as in a real cluster weak-lensing analysis.
+
+We build the positions as an `al.Grid2DIrregular` of (y, x) coordinates and pass them to the simulator's
+`via_tracer_from` method. (For a quick uniform-square catalogue with no core exclusion, the simulator also
+offers `via_tracer_random_positions_from(tracer=tracer, n_galaxies=..., grid_extent=...)`.)
+"""
+rng = np.random.default_rng(1)
+
+n_galaxies = 1500
+radius_inner = 50.0  # arc-seconds — inside this we are in the strong-lensing core.
+radius_outer = 200.0  # arc-seconds — the edge of the simulated weak-lensing field.
+
+radii = np.sqrt(rng.uniform(radius_inner**2.0, radius_outer**2.0, n_galaxies))
+phi = rng.uniform(0.0, 2.0 * np.pi, n_galaxies)
+
+positions = al.Grid2DIrregular(
+    values=np.stack([radii * np.sin(phi), radii * np.cos(phi)], axis=1)
+)
+
+"""
 __Simulator__
 
-`SimulatorShearYX` takes a shape-noise level and an optional random seed. A `noise_sigma` of 0.3 is a typical
-ground-based survey value; reduce it to 0.0 to inspect the noise-free shear field.
+`SimulatorShearYX` takes a shape-noise level and an optional random seed. A `noise_sigma` of 0.25 is a typical
+per-component shape-noise value for a weak-lensing survey; reduce it to 0.0 to inspect the noise-free shear field.
 
-The `via_tracer_random_positions_from` helper draws `n_galaxies` uniform-random source positions inside a square
-of half-width `grid_extent` (in arc-seconds). For finer control, build your own `aa.Grid2DIrregular` of (y, x)
-positions and call `simulator.via_tracer_from(tracer=tracer, grid=grid)` instead.
+`via_tracer_from` evaluates the tracer's shear at the supplied (y, x) positions and adds the shape noise. (The
+`via_tracer_random_positions_from` helper used by the earlier tutorials instead draws its own uniform-random
+square of positions; here we pass an explicit annulus so the core is excluded.)
 """
-simulator = al.SimulatorShearYX(noise_sigma=0.3, seed=1)
+simulator = al.SimulatorShearYX(noise_sigma=0.25, seed=1)
 
-dataset = simulator.via_tracer_random_positions_from(
+dataset = simulator.via_tracer_from(
     tracer=tracer,
-    n_galaxies=200,
-    grid_extent=3.0,
+    grid=positions,
     name=dataset_name,
 )
 
@@ -131,7 +170,7 @@ the classic visualization used for merging clusters (e.g. the Bullet cluster) an
 
 `aplt.plot_convergence_map` bins the irregular catalogue onto a regular grid, applies a small Gaussian
 smoothing (raw per-cell shears are shape-noise dominated) and plots the E-mode reconstruction. For this
-Isothermal lens the map peaks at the lens centre at (0.0", 0.0"). Two caveats to remember: the mean of the
+Isothermal cluster the map peaks at the lens centre at (0.0", 0.0"). Two caveats to remember: the mean of the
 map is unconstrained (the mass-sheet degeneracy) and FFT periodicity causes artefacts near the field edges —
 for quantitative masses, fit a mass model with `scripts/weak/modeling.py` instead.
 """


### PR DESCRIPTION
Closes #279.

## Why

The `scripts/weak/` `simple` example used a galaxy-scale Isothermal lens (`einstein_radius=1.6"`)
with 200 background galaxies drawn uniformly in a 3.0"-half-width square. That box reaches inward
to `r ~ 0.14"`, so many galaxies sit at/inside the Einstein radius where `|gamma| = theta_E/(2r)`
is order 0.2–1 — its "31σ detection" came from the **strong/intermediate** regime, not genuinely
weak shear (the same catalogue in a true 5–20" weak annulus drops to ~3σ). The example didn't look
like the weak lensing it teaches.

## What changed

- **`simulator.py`** — cluster-scale Isothermal `einstein_radius=25.0"`, `axis_ratio=0.8`; 1500
  background galaxies drawn uniform-in-area in a **50"–200" annulus** (outside the strong-lensing
  core, ~45 gal/arcmin²) via an explicit `Grid2DIrregular` + `via_tracer_from`; `noise_sigma=0.25`;
  prose rewritten around the cluster + core-exclusion narrative.
- **`modeling.py`** — priors widened from galaxy-scale defaults (Einstein radius Uniform 0–8",
  centre Gaussian σ=0.1") to cluster scale (Einstein radius 0–60", centre σ=20"), with a new
  "Cluster-Scale Priors" note; dataset description and framing updated.
- **`fit.py`, `likelihood_function.py`** — hand-picked truth synced (`einstein_radius=25.0`,
  `axis_ratio=0.8`), `2N` sanity number 400 → 3000, dataset prose updated.
- `features/strong_lensing/` left unchanged (deliberately galaxy-scale joint example).
- `notebooks/weak/*.ipynb` and `markdown/weak/*.md` are generated from these scripts by
  PyAutoBuild at build/release time and are not hand-edited here.

## Verification (autolens 2026.7.15.1, clean venv, all four scripts run)

- `simulator.py` → 1500-galaxy 50–200" annulus catalogue; detection **S/N ≈ 16σ**;
  median `|gamma|=0.085`, max `0.27` (every galaxy weak, below the 0.25 shape noise).
- `fit.py` / `likelihood_function.py` → `χ² = 2974` for 3000 dof; by-hand == `FitWeak` ==
  `AnalysisWeak` log-likelihood.
- `modeling.py` (Nautilus, ~2 min) → `einstein_radius` recovered **24.3" (1σ 22.9–25.8;
  truth 25.0 within 0.5σ)**; ellipticity and centre within ~1σ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzQpJekBuuB9pQdYGMWyzY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzQpJekBuuB9pQdYGMWyzY)_