### PR TITLE
fix: add timeouts to cluster network downloads so CI can't hang

### DIFF
--- a/scripts/cluster/lenstool/data.py
+++ b/scripts/cluster/lenstool/data.py
@@ -121,7 +121,10 @@ for name in MAHLER_FILES:
     path = LENSTOOL_PATH / name
     if not path.exists():
         print(f"Downloading {name} from the Mahler et al. repository...")
-        urllib.request.urlretrieve(f"{MAHLER_BASE}/{name}", path)
+        # Explicit timeout so a stalled server fails fast instead of hanging
+        # indefinitely (`urlretrieve` has no timeout).
+        with urllib.request.urlopen(f"{MAHLER_BASE}/{name}", timeout=30) as response:
+            path.write_bytes(response.read())
 
 """
 __Coordinate Convention__ (see module docstring)
@@ -327,7 +330,11 @@ elif not cutout_path.exists():
     mosaic_path = DATASET_PATH / "f814w_mosaic.fits"
     if not mosaic_path.exists():
         print("Downloading the RELICS F814W mosaic (96 MB, one-off)...")
-        urllib.request.urlretrieve(RELICS_F814W_URL, mosaic_path)
+        # Explicit timeout so a stalled server fails fast instead of hanging
+        # indefinitely (`urlretrieve` has no timeout). The timeout is per socket
+        # read, so a large-but-progressing download is unaffected.
+        with urllib.request.urlopen(RELICS_F814W_URL, timeout=60) as response:
+            mosaic_path.write_bytes(response.read())
 
     with fits.open(mosaic_path) as hdul:
         data = hdul[0].data

--- a/scripts/cluster/start_here.py
+++ b/scripts/cluster/start_here.py
@@ -150,7 +150,12 @@ if not data_fits_path.exists():
 
     print("Downloading HST H-band image of Abell 2744 for visualization (one-off, ~1.4 MB) ...")
     try:
-        urllib.request.urlretrieve(HIPS2FITS_URL, data_fits_path)
+        # An explicit timeout is essential: `urlretrieve` has none, so a slow or
+        # stalled hips2fits response hangs the script indefinitely (in CI this
+        # blocked until the build-script timeout). On any failure we continue —
+        # the image is used for visualization only.
+        with urllib.request.urlopen(HIPS2FITS_URL, timeout=30) as response:
+            data_fits_path.write_bytes(response.read())
     except Exception as e:
         print(f"Image download failed ({e}) — continuing without it (visualization only).")
 


### PR DESCRIPTION
## Problem

In PyAutoHeart's release-fidelity validation, `scripts/cluster/start_here.py` **timed out at the 1800s build-script cap**, while every other cluster script passed in seconds (`modeling.py` 48.5s, `csv_api.py` 4.3s, …). The one thing `start_here.py` does that the others don't is a network download:

```python
urllib.request.urlretrieve(HIPS2FITS_URL, data_fits_path)   # no timeout
```

`urlretrieve` has **no timeout**, so when the CDS `hips2fits` service stalls the request blocks indefinitely. The surrounding `try/except` can't help — a hang raises no exception.

## Fix

Use `urlopen(..., timeout=...)` + write so a stalled server fails fast:
- `start_here.py` — HST visualization image (timeout 30s); the existing `except` skips it gracefully (visualization-only).
- `lenstool/data.py` — the same no-timeout pattern appears twice (the Mahler files and the **96 MB** RELICS mosaic). These are required inputs, so a timeout raises fast (30s / 60s) instead of hanging the 1800s cap. The socket timeout is per-read, so a large-but-progressing download is unaffected.

Both scripts compile; the workspace size guard passes; no bare `urlretrieve` remains under `scripts/cluster/`.

## Notes

- This is a **pre-existing** issue, unrelated to the autoconf→autonerves rename; found while auditing PyAutoHeart's nightly reds.
- The fix is validated by PyAutoHeart's next release-fidelity nightly (the cluster scripts aren't in the per-PR smoke subset).
- The notebook copies (`notebooks/cluster/start_here.ipynb`, `notebooks/cluster/lenstool/data.ipynb`) carry the same download code and should be regenerated from these scripts via the standard PyAutoHands flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_