### PR TITLE
chore: un-park mask_irregular no_run marker (bug already fixed)

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -43,6 +43,5 @@
 - interferometer/casa_reduction # Requires CASA MeasurementSet output, not runnable standalone
 - dataset/imaging/slacs1430+4105 # Dataset folder contains data.py helper, not a runnable script
 - group/slam # NEEDS_FIX 2026-04-10 - PriorException: upper limit must be greater than lower limit in group SLaM pipeline
-- imaging/data_preparation/manual/mask_irregular # NEEDS_FIX 2026-04-10 - silent failure, needs investigation
 - interferometer/features/pixelization/delaunay # NEEDS_FIX 2026-07-21 - autofit.exc.FitException raised in interferometer log_likelihood_function (analysis.py:182); old (2,2)v(1032,1032) broadcast gone but a non-PD-family FitException remains under PYAUTO_DISABLE_JAX=1 test-mode bypass (separate from the imaging pixelization cluster fixed in #300)
 - multi/features/wavelength_dependence/modeling # NEEDS_FIX 2026-04-10 - autofit.exc.FitException in multi-wavelength modeling


### PR DESCRIPTION
## Summary
Removes the stale `imaging/data_preparation/manual/mask_irregular` NEEDS_FIX
marker from `config/build/no_run.yaml`. The 2026-04-10 'silent failure' was
`Convolver.from_gaussian` API drift, fixed by PyAutoArray #360/#361. Completes
the fold-in tail deferred from #300. Refs #303.

**Verified green:** `scripts/imaging/data_preparation/manual/mask_irregular.py`
runs rc=0 and writes `mask.fits` under the build env (`PYAUTO_DISABLE_JAX=1`,
`PYAUTO_TEST_MODE=2`, real dataset) — only the benign pre-existing
"No blurring_image" warning.

## Scripts Changed
No script edits -- `config/build/no_run.yaml` only. Marker removed:
- `imaging/data_preparation/manual/mask_irregular` -- was `NEEDS_FIX 2026-04-10 silent failure` (verified green)

## Test Plan
- [x] mask_irregular.py verified green end-to-end (build env, real dataset)

Generated by the PyAutoLabs agent workflow.