### PR TITLE
chore: un-park mask_irregular no_run marker (bug already fixed)

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -43,6 +43,5 @@
 - interferometer/casa_reduction # Requires CASA MeasurementSet output, not runnable standalone
 - dataset/imaging/slacs1430+4105 # Dataset folder contains data.py helper, not a runnable script
 - group/slam # NEEDS_FIX 2026-04-10 - PriorException: upper limit must be greater than lower limit in group SLaM pipeline
-- imaging/data_preparation/manual/mask_irregular # NEEDS_FIX 2026-04-10 - silent failure, needs investigation
 - interferometer/features/pixelization/delaunay # NEEDS_FIX 2026-07-21 - autofit.exc.FitException raised in interferometer log_likelihood_function (analysis.py:182); old (2,2)v(1032,1032) broadcast gone but a non-PD-family FitException remains under PYAUTO_DISABLE_JAX=1 test-mode bypass (separate from the imaging pixelization cluster fixed in #300)
 - multi/features/wavelength_dependence/modeling # NEEDS_FIX 2026-04-10 - autofit.exc.FitException in multi-wavelength modeling


### PR DESCRIPTION
Removes the stale `imaging/data_preparation/manual/mask_irregular` NEEDS_FIX marker (2026-04-10 "silent failure").

**The bug is already fixed.** On clean `main` the script runs **PASSED (14.0s)** through the build's own `execute_script` runner (`has_failures=False`). Root cause was `Convolver.from_gaussian` / `convolved_image_from` API drift, since resolved by the PyAutoArray convolver consolidation (#360/#361). Runs headless, only a soft `No blurring_image provided` UserWarning (not a failure), no GUI dependency — **not** a `gui/*` reclassify.

Companion to the autogalaxy_workspace + HowToGalaxy cleanup (merged via autogalaxy_workspace#140) and the HowToLens orphaned-marker removal. Closes the `autolens_workspace` share of the 4-imaging-repo mask_irregular parking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)