### PR TITLE
fix: multi-wavelength modeling green (auto-simulate + SersicCore effective_radius=0)

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -44,4 +44,3 @@
 - dataset/imaging/slacs1430+4105 # Dataset folder contains data.py helper, not a runnable script
 - group/slam # NEEDS_FIX 2026-04-10 - PriorException: upper limit must be greater than lower limit in group SLaM pipeline
 - interferometer/features/pixelization/delaunay # NEEDS_FIX 2026-07-21 - autofit.exc.FitException raised in interferometer log_likelihood_function (analysis.py:182); old (2,2)v(1032,1032) broadcast gone but a non-PD-family FitException remains under PYAUTO_DISABLE_JAX=1 test-mode bypass (separate from the imaging pixelization cluster fixed in #300)
-- multi/features/wavelength_dependence/modeling # NEEDS_FIX 2026-04-10 - autofit.exc.FitException in multi-wavelength modeling

--- a/notebooks/multi/features/wavelength_dependence/modeling.ipynb
+++ b/notebooks/multi/features/wavelength_dependence/modeling.ipynb
@@ -174,7 +174,31 @@
     "dataset_label = \"imaging\"\n",
     "dataset_name = \"wavelength_dependence\"\n",
     "\n",
-    "dataset_path = Path(\"dataset\") / dataset_type / dataset_label / dataset_name\n",
+    "dataset_path = Path(\"dataset\") / dataset_type / dataset_label / dataset_name"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the dataset does not already exist on your system, it is created by running the corresponding simulator\n",
+    "script. This ensures the example can be run without manually simulating the data first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "if al.util.dataset.should_simulate(str(dataset_path)):\n",
+    "    import subprocess\n",
+    "    import sys\n",
+    "\n",
+    "    subprocess.run(\n",
+    "        [sys.executable, \"scripts/multi/features/wavelength_dependence/simulator.py\"],\n",
+    "        check=True,\n",
+    "    )\n",
     "\n",
     "dataset_list = [\n",
     "    al.Imaging.from_fits(\n",

--- a/scripts/multi/features/wavelength_dependence/modeling.py
+++ b/scripts/multi/features/wavelength_dependence/modeling.py
@@ -87,6 +87,19 @@ dataset_name = "wavelength_dependence"
 
 dataset_path = Path("dataset") / dataset_type / dataset_label / dataset_name
 
+"""
+If the dataset does not already exist on your system, it is created by running the corresponding simulator
+script. This ensures the example can be run without manually simulating the data first.
+"""
+if al.util.dataset.should_simulate(str(dataset_path)):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/multi/features/wavelength_dependence/simulator.py"],
+        check=True,
+    )
+
 dataset_list = [
     al.Imaging.from_fits(
         data_path=Path(dataset_path) / f"{waveband}_data.fits",


### PR DESCRIPTION
## Summary

Makes `multi/features/wavelength_dependence/modeling` runnable green (was `NEEDS_FIX`). Two issues combined:
1. **`SersicCore` ZeroDivisionError on `effective_radius=0`** — the marker's stated "FitException" was really this; the model's `effective_radius = wavelength*m + c` relation (symmetric-about-0 `m,c` priors) gives `effective_radius=0` at the test-mode median. Fixed upstream in **PyAutoGalaxy#515**.
2. **Missing auto-simulate block** — unlike its sibling `multi/modeling.py`, this script had no dataset auto-simulation, so it `FileNotFoundError`ed on a fresh checkout. Added the standard `should_simulate → subprocess simulator.py` block.

With both, the script runs green from a clean state under the CI smoke env.

## Scripts Changed
- `scripts/multi/features/wavelength_dependence/modeling.py` — add dataset auto-simulate block (mirrors `multi/modeling.py`)
- `config/build/no_run.yaml` — drop the `multi/features/wavelength_dependence/modeling` NEEDS_FIX marker
- `notebooks/multi/features/wavelength_dependence/modeling.ipynb` — regenerated

## Upstream PR
https://github.com/PyAutoLabs/PyAutoGalaxy/pull/515

## Test Plan
- [x] `modeling.py` runs green from clean (auto-simulates then models; EXIT 0) under `PYAUTO_DISABLE_JAX=1 TEST_MODE=2 SMALL_DATASETS=1`
- [x] `run_smoke.py` — 9/9 passed (against the fixed PyAutoGalaxy branch)
- [ ] Merges after PyAutoGalaxy#515 (library-first)

Generated by the PyAutoLabs agent workflow.