### PR TITLE
chore: drop stale interferometer delaunay NEEDS_FIX marker (#308)

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -43,4 +43,3 @@
 - interferometer/casa_reduction # Requires CASA MeasurementSet output, not runnable standalone
 - dataset/imaging/slacs1430+4105 # Dataset folder contains data.py helper, not a runnable script
 - group/slam # NEEDS_FIX 2026-04-10 - PriorException: upper limit must be greater than lower limit in group SLaM pipeline
-- interferometer/features/pixelization/delaunay # NEEDS_FIX 2026-07-21 - autofit.exc.FitException raised in interferometer log_likelihood_function (analysis.py:182); old (2,2)v(1032,1032) broadcast gone but a non-PD-family FitException remains under PYAUTO_DISABLE_JAX=1 test-mode bypass (separate from the imaging pixelization cluster fixed in #300)


### PR DESCRIPTION
## Summary

Removes the stale `interferometer/features/pixelization/delaunay` `NEEDS_FIX` marker. The script is now deterministically green on `main` under the CI smoke env (verified 3×, fresh dataset) — recent concurrent work fixed the non-PD `FitException`.

## Scripts Changed
- `config/build/no_run.yaml` — drop the `interferometer/features/pixelization/delaunay` NEEDS_FIX entry

## Test Plan
- [x] `scripts/interferometer/features/pixelization/delaunay.py` — EXIT 0 (fresh data, smoke env)
- [x] `run_smoke.py` — 9/9 passed

## Notes
What fixed it (not this PR): prime suspect `PyAutoArray#396` (`SMALL_DATASETS` cap 15×15 → even 16×16 — the failure was grid-size sensitive), not the `f1817af0` GaussianKernel PD-guard (this script uses `ConstantSplit`/`AdaptSplit`). Latent, out of scope: `AnalysisInterferometer.log_likelihood_function` wraps any error as `FitException` (`analysis.py:175-182`), which masked the real error.

Generated by the PyAutoLabs agent workflow.