### PR TITLE
test(smoke): un-park interferometer Delaunay (tolerated by PyAutoFit#1408) + add to smoke

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -43,4 +43,3 @@
 - interferometer/casa_reduction # Requires CASA MeasurementSet output, not runnable standalone
 - dataset/imaging/slacs1430+4105 # Dataset folder contains data.py helper, not a runnable script
 - group/slam # NEEDS_FIX 2026-04-10 - PriorException: upper limit must be greater than lower limit in group SLaM pipeline
-- interferometer/features/pixelization/delaunay # NEEDS_FIX 2026-07-21 - INTERMITTENT "ValueError: Points cannot contain NaN" from the Delaunay/qhull triangulation in the interferometer path; flaky on CI py3.12 (fails ~50%, passes locally 4/4 + 20/20 prior draws). Real latent bug: traced/relocated source-plane mesh occasionally has NaN vertices. The old (2,2)v(1032,1032) broadcast IS gone. Root-cause investigation tracked separately.

--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -12,7 +12,10 @@ multi/modeling.py
 guides/galaxies.py
 # guides/results/start_here.py  # disabled: depends on prior search output in output/ dir (not generated during smoke tests)
 guides/modeling/cookbook.py
-# imaging Delaunay pixelization: the 2026-04-10 parked FitException is fixed; guard against
-# regression. Its inline likelihood-guide section exercises a real Delaunay inversion.
-# (interferometer Delaunay stays parked in no_run.yaml — intermittent qhull NaN, flaky on CI.)
+# Delaunay pixelization: the 2026-04-10 parked FitExceptions are fixed. The interferometer
+# script's intermittent qhull NaN (source_pix_2 Hilbert mesh) is now tolerated in test-mode by
+# PyAutoFit#1408 (bypass treats a single-eval FitException as resample-to-reject), so it no
+# longer flakily hard-fails. Both scripts' inline likelihood-guide sections exercise a real
+# Delaunay inversion. (Phase 2 / PyAutoLens#640: fix the underlying NaN/non-PD producer.)
 imaging/features/pixelization/delaunay.py
+interferometer/features/pixelization/delaunay.py


### PR DESCRIPTION
Phase 1b of PyAutoLens#640 (follow-up to #307). Library-first: **PyAutoFit#1408 is merged to main**, so this workspace change is now safe.

### What & why
The interferometer Delaunay script intermittently hard-failed CI smoke with `ValueError: Points cannot contain NaN` (qhull) via `source_pix_2` (Hilbert adaptive mesh) → `_fit_bypass_test_mode` single eval. PyAutoFit#1408 makes the `TEST_MODE=2` bypass tolerate a single-eval `FitException` (keep the `-1.0e99` sentinel + log), mirroring the real sampler's resample-to-reject (`fitness.py:256`). So the script no longer flakily hard-fails.

- Remove the interferometer Delaunay `NEEDS_FIX` entry from `config/build/no_run.yaml`.
- Add `interferometer/features/pixelization/delaunay.py` to `smoke_tests.txt` (both Delaunay scripts now gated; their inline likelihood-guide sections exercise a real Delaunay inversion).

### Verification
`python .github/scripts/run_smoke.py` → **11/11 passed** (imaging delaunay 23.2s, interferometer delaunay 25.5s), against the merged PyAutoFit fix.

### Follow-up
Phase 2 (PyAutoLens#640): fix the underlying NaN/non-PD producer (`fnnls.py:134` divide-by-zero / degenerate Hilbert-mesh vertices) so the fit is *correct*, not merely tolerated.

Refs PyAutoLens#640, PyAutoFit#1408, #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)