### PR TITLE
chore: un-park group/slam (stale NEEDS_FIX, bug fixed)

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -42,4 +42,3 @@
 - point_source/features/multiple_sources/modeling # Blocked by PyAutoLens #480: same root cause as simulator above
 - interferometer/casa_reduction # Requires CASA MeasurementSet output, not runnable standalone
 - dataset/imaging/slacs1430+4105 # Dataset folder contains data.py helper, not a runnable script
-- group/slam # NEEDS_FIX 2026-04-10 - PriorException: upper limit must be greater than lower limit in group SLaM pipeline


### PR DESCRIPTION
Removes the stale `# NEEDS_FIX 2026-04-10` marker on `group/slam` — the "PriorException: upper limit must be greater than lower limit" no longer reproduces; the group SLaM pipeline completes (exit 0).

Closes part of PyAutoLabs/autolens_workspace_test#191.

Parked-script triage: reproduced on clean main under PYAUTO_TEST_MODE=2 (the harness mode). Verified fixed → un-parked (removed the NEEDS_FIX marker so the script runs in validation again).

## Scripts Changed

None (config-only edit to config/build/no_run.yaml). The following previously-skipped script returns to validation:
- `scripts/group/slam.py`