### PR TITLE
docs(no_run): correct the SLOW-skip timeout cap (300s/1800s, not 60s)

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -6,7 +6,8 @@
 #
 # SLOW-skip convention:
 #   Entries tagged `# SLOW <YYYY-MM-DD> - <reason>` mark scripts that are
-#   skipped because they exceed the 60s per-script timeout cap. These are
+#   skipped because they exceed the per-script timeout cap (300s by
+#   default; 1800s for mode=release runs). These are
 #   NOT permanent skips — every mega-run surfaces them with a loud warning
 #   banner. Fix the performance issue and remove the SLOW marker.
 #


### PR DESCRIPTION
Companion to **PyAutoLabs/PyAutoHands#172**.

The `config/build/no_run.yaml` header documented a **"60s per-script timeout cap"**. No such cap is enforced. The real values:

- **300s** — smoke/default: `PyAutoHands/autobuild/build_util.py:12`, `TIMEOUT_SECS = int(os.environ.get("BUILD_SCRIPT_TIMEOUT", "300"))`.
- **1800s** — `mode=release`: `PyAutoHeart/.github/workflows/workspace-validation.yml:308`.

A 5× understatement of the cap biases every "is this script too slow to un-skip?" judgement in the same direction — toward parking scripts that would in fact pass. It did exactly that while triaging autolens_workspace_test#193: a clean run of `database/scrape/general` measured 214s, which reads as an obvious SLOW-skip against 60s but has ~86s of *headroom* against the real 300s cap.

Comment-only; one line of the header replaced by two. No behaviour change.

## Scripts Changed

None (`config/build/no_run.yaml` header comment only).
