### PR TITLE
chore: remove 7 zero-match no_run entries, including a year-dead plot/visuals skip

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -4,6 +4,13 @@
 #   - Entries without '/' match the file stem exactly
 # Add an inline # comment to document the reason for skipping.
 #
+# THIS LIST IS REPO-LOCAL. Do not copy entries in from HowToLens (or any other
+# repo), and do not copy entries out. Tutorial stems such as `tutorial_searches`
+# belong to HowToLens and can never match a file here; a pattern that matches
+# nothing is silently inert, not a skip. Every entry below must match a file in
+# THIS repo — verify with `should_skip` in PyAutoHands/autobuild/build_util.py
+# before adding one, and re-check the pattern whenever a script is moved.
+#
 # SLOW-skip convention:
 #   Entries tagged `# SLOW <YYYY-MM-DD> - <reason>` mark scripts that are
 #   skipped because they exceed the per-script timeout cap (300s by
@@ -18,17 +25,12 @@
 #   banner. Investigate the failure, fix the underlying bug, and remove
 #   the NEEDS_FIX marker.
 
-- tutorial_searches
 - guides/results/database/start_here # SLOW 2026-04-10 - previously failed fast on a broken aggregator query; now runs the real aggregator and exceeds 60s
-- tutorial_5_borders # Cant get right masks, need proper update.
-- tutorial_6_model_fit # InversionException due to test mode
 - gui/extra_galaxies_centres # GUI scripts cannot be run
 - gui/mask_extra_galaxies # GUI scripts cannot be run
 - gui/lens_light_centre # GUI scripts cannot be run
 - gui/mask # GUI scripts cannot be run
 - gui/positions # GUI scripts cannot be run
-- deflections # Output HDU not supported for VectorYX Detections.
-- deflections_source_snr # Output HDU not supported for VectorYX Detections.
 - fits_make # Test mode does not output .fits images.
 - png_make # Test mode does not output .png images.
 - time_delays # Test mode does not support cosmology ift
@@ -38,10 +40,8 @@
 - mass_stellar_dark/slam # Requires CSE to be JAX enabled.
 - detect/database # Unsure but not a feature actively used currently.
 - imaging/features/advanced/subhalo/sensitivity/ # All sensitivity scripts need updating when visualization refactored.
-- plot/visuals # Bugged, but visuals being refactored soon.
 - point_source/features/multiple_sources/simulator # Blocked by PyAutoLens #480: solver finds 0 positions for intermediate-plane source
 - point_source/features/multiple_sources/modeling # Blocked by PyAutoLens #480: same root cause as simulator above
 - interferometer/casa_reduction # Requires CASA MeasurementSet output, not runnable standalone
-- dataset/imaging/slacs1430+4105 # Dataset folder contains data.py helper, not a runnable script
 - cluster/start_here # SLOW 2026-07-22 - hits the full 1800s mode=release cap in workspace-validation (PyAutoHeart run 29912642195). Script-specific, not a shard-wide problem: every other cluster script passes, the next-slowest being lenstool/modeling.py at 137.8s. Consistent with cluster scripts being known un-smoke-able (>500s even in TEST_MODE). Not yet profiled — SLOW-skipped to unblock the release; remove once the cost is found and fixed (autolens_workspace#314).
 - weak/features/strong_lensing/a2744 # SLOW 2026-07-22 - hits the full 1800s mode=release cap in workspace-validation (PyAutoHeart run 29912642195). Script-specific: its sibling weak/real_data/a2744.py passes in 8.9s and the next-slowest weak script is modeling.py at 23.6s, so the cost is in the strong_lensing feature path rather than the A2744 dataset itself. Not yet profiled — SLOW-skipped to unblock the release (autolens_workspace#314).


### PR DESCRIPTION
## Summary

7 of this repo's 27 `no_run.yaml` entries matched **zero files**. The other 20 are live and untouched.

- `tutorial_searches`, `tutorial_5_borders`, `tutorial_6_model_fit` are **HowToLens tutorial stems copied in from that repo** — they can never match a file in a workspace. (The copy runs both ways: 18 of HowToLens' 28 dead entries are autolens_workspace paths.)
- `deflections` and `deflections_source_snr` name no file in this repo or in its history.
- `dataset/imaging/slacs1430+4105` points outside `scripts/`, the only tree `run_all` walks (`run_all.py:78`), so it was inert. Its own comment admitted as much.

### `plot/visuals` was not cruft — it was an active silent failure

The file moved `scripts/plot/visuals.py` → `scripts/guides/plot/examples/visuals.py` in `9e1a50dc4` (2025-07-18) and the pattern was never updated. A script commented *"Bugged, but visuals being refactored soon"* has therefore been **running in the build for a year**, not skipped.

Rather than guess, it was re-tested under the real build env profile via `autobuild repro_command`:

```
(cd autolens_workspace && env PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 \
  PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_DISABLE_JAX=1 \
  PYAUTO_FAST_PLOTS=1 JAX_ENABLE_X64=True NUMBA_CACHE_DIR=/tmp/numba_cache \
  MPLCONFIGDIR=/tmp/matplotlib python3 scripts/guides/plot/examples/visuals.py)
```

**Result: exit 0, no output, no warnings.** The comment is obsolete, so the entry is dropped as stale rather than re-spelled to the moved path.

Part of a 5-repo census (PyAutoLabs/HowToLens#46) that found **50 of 122 `no_run.yaml` entries (41%) dead** across the organism, plus 11 dead `env_vars` patterns. The cleaned file gains a header recording the matcher rule, that the list is repo-local, and that a pattern must be re-checked whenever a script moves — which is exactly what `plot/visuals` shows.

## Scripts Changed

None — this PR is config-only.

- `config/build/no_run.yaml` — 27 entries → 20

## Test Plan

- [x] Smoke tests pass — **11/11 passed**
- [x] `scripts/guides/plot/examples/visuals.py` runs clean under the build env profile (exit 0)
- [x] **Proven behaviour-neutral**: for all 360 scripts here, the resolved `should_skip` set and the fully-resolved `build_env_for_script` dict are byte-identical before vs after, because every removed entry matched zero files. Verified with the real matcher (`PyAutoHands/autobuild/build_util.py:143`).
- [x] Census re-run: 0 zero-match entries remain, across all 10 build targets

Generated by the PyAutoLabs agent workflow.