### PR TITLE
chore: align env_vars/env_vars_release defaults key order

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -9,16 +9,16 @@
 #   - Patterns without '/' match the file stem exactly
 
 defaults:
-  PYAUTO_TEST_MODE: "2"                 # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
-  PYAUTO_SKIP_FIT_OUTPUT: "1"           # Skip pre/post-fit I/O, VRAM profiling, result text
-  PYAUTO_SKIP_VISUALIZATION: "1"        # Skip fit visualization and plotting
-  PYAUTO_SKIP_CHECKS: "1"              # Skip mesh validation, position checks, weight thresholds
-  PYAUTO_SMALL_DATASETS: "1"           # Cap grids/masks to 15x15, reduce MGE gaussians
-  PYAUTO_DISABLE_JAX: "1"              # Force use_jax=False, avoid JIT compilation overhead
-  PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() + critical curve/caustic overlays
-  JAX_ENABLE_X64: "True"               # Enable 64-bit precision in JAX
-  NUMBA_CACHE_DIR: "/tmp/numba_cache"   # Writable cache dir for numba
-  MPLCONFIGDIR: "/tmp/matplotlib"       # Writable config dir for matplotlib
+  PYAUTO_TEST_MODE: "2"                     # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
+  PYAUTO_SKIP_FIT_OUTPUT: "1"               # Skip pre/post-fit I/O, VRAM profiling, result text
+  PYAUTO_SKIP_VISUALIZATION: "1"            # Skip fit visualization and plotting
+  PYAUTO_SKIP_CHECKS: "1"                   # Skip mesh validation, position checks, weight thresholds
+  PYAUTO_SMALL_DATASETS: "1"                # Cap grids/masks to 15x15, reduce MGE gaussians
+  PYAUTO_DISABLE_JAX: "1"                   # Force use_jax=False, avoid JIT compilation overhead
+  PYAUTO_FAST_PLOTS: "1"                    # Skip tight_layout() + critical curve/caustic overlays
+  JAX_ENABLE_X64: "True"                    # Enable 64-bit precision in JAX
+  NUMBA_CACHE_DIR: "/tmp/numba_cache"       # Writable cache dir for numba
+  MPLCONFIGDIR: "/tmp/matplotlib"           # Writable config dir for matplotlib
 
 overrides:
   # start_here scripts load real FITS data that breaks with small datasets

--- a/config/build/env_vars_release.yaml
+++ b/config/build/env_vars_release.yaml
@@ -25,17 +25,17 @@
 #   - Patterns without '/' match the file stem exactly
 
 defaults:
-  PYAUTO_TEST_MODE: "1"                 # reduced iterations (real sampler), not bypassed
-  PYAUTO_SMALL_DATASETS: "1"           # cap grids/masks to 15x15, reduce MGE gaussians
-  PYAUTO_FAST_PLOTS: "1"               # skip tight_layout() + critical curve/caustic overlays
-  PYAUTO_SKIP_FIT_OUTPUT: "0"          # real fit output (release fidelity, not smoke)
-  PYAUTO_SKIP_VISUALIZATION: "0"       # real visualization (release fidelity, not smoke)
-  PYAUTO_SKIP_CHECKS: "0"              # real mesh/position/weight checks (release fidelity)
-  PYAUTO_DISABLE_JAX: "0"              # JAX enabled (release fidelity, not smoke)
+  PYAUTO_TEST_MODE: "1"                     # reduced iterations (real sampler), not bypassed
+  PYAUTO_SKIP_FIT_OUTPUT: "0"               # real fit output (release fidelity, not smoke)
+  PYAUTO_SKIP_VISUALIZATION: "0"            # real visualization (release fidelity, not smoke)
+  PYAUTO_SKIP_CHECKS: "0"                   # real mesh/position/weight checks (release fidelity)
+  PYAUTO_SMALL_DATASETS: "1"                # cap grids/masks to 15x15, reduce MGE gaussians
+  PYAUTO_DISABLE_JAX: "0"                   # JAX enabled (release fidelity, not smoke)
+  PYAUTO_FAST_PLOTS: "1"                    # skip tight_layout() + critical curve/caustic overlays
   PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"  # TestPyPI dev version won't match the workspace pin
-  JAX_ENABLE_X64: "True"               # enable 64-bit precision in JAX
-  NUMBA_CACHE_DIR: "/tmp/numba_cache"   # writable cache dir for numba
-  MPLCONFIGDIR: "/tmp/matplotlib"       # writable config dir for matplotlib
+  JAX_ENABLE_X64: "True"                    # enable 64-bit precision in JAX
+  NUMBA_CACHE_DIR: "/tmp/numba_cache"       # writable cache dir for numba
+  MPLCONFIGDIR: "/tmp/matplotlib"           # writable config dir for matplotlib
 
 overrides:
   # start_here scripts load real FITS data that breaks with small datasets


### PR DESCRIPTION
## Summary

The two env profiles under `config/build/` — `env_vars.yaml` (the `smoke` profile driving the per-PR CI gate) and `env_vars_release.yaml` (the release-fidelity profile) — listed the same keys in different orders, so they could not be read or diffed side by side. This applies one canonical key order to the `defaults:` block of both, and aligns the trailing comment column.

Canonical order (union of every key in use across the workspace, smoke-first):

```
PYAUTO_TEST_MODE
PYAUTO_SKIP_FIT_OUTPUT
PYAUTO_SKIP_VISUALIZATION
PYAUTO_SKIP_CHECKS
PYAUTO_SMALL_DATASETS
PYAUTO_DISABLE_JAX
PYAUTO_FAST_PLOTS
PYAUTO_SKIP_WORKSPACE_VERSION_CHECK
JAX_ENABLE_X64
MPLBACKEND
NUMBA_CACHE_DIR
MPLCONFIGDIR
```

No keys added or removed, no values changed, each key keeps its own comment text, and `overrides:` is untouched (it is an ordered list of pattern rules where order *is* load-bearing).

**Provably a no-op.** `defaults` is applied by plain dict iteration in `PyAutoHands/autohands/env_config.py`, so its order cannot affect the resolved environment.

## Scripts Changed

None — configuration only. No file under `scripts/` is touched, so no notebook regeneration is involved.

- `config/build/env_vars.yaml` — `defaults:` reordered to the canonical order; comment column aligned.
- `config/build/env_vars_release.yaml` — same.

## Test Plan

- [x] Resolved-env diff before/after: for every script in the repo × both profiles, resolved from an **empty** base via `resolve_clean()` (`PyAutoHands/autohands/validate_env_profiles.py`). **Identical** — this is a strictly stronger check than a smoke run for a config-only change, since it proves every script's environment is byte-for-byte unchanged rather than sampling a subset.
- [x] `validate_env_profiles.py` verdict byte-identical to `main` (no new errors or warnings).
- [x] `git diff --stat` contains nothing but `config/build/env_vars*.yaml`.
- [x] `diff` of the two profiles' `defaults:` blocks now shows only genuine value/comment differences, with keys lining up row-for-row.

Part of a workspace-wide sweep across 10 repos. Refs PyAutoLabs/autolens_workspace#321.

Generated by the PyAutoLabs agent workflow.
