### PR TITLE
refactor: migrate smoke env overrides to in-file '# ENV:' declarations

### DIFF
--- a/config/build/profile_release.yaml
+++ b/config/build/profile_release.yaml
@@ -62,10 +62,9 @@ overrides:
   # re-simulation when data already exists.
   - pattern: "guides/"
     set: { PYAUTO_SMALL_DATASETS: "0" }
-  # Results guides require the samples promised by their explicit n_like_max
-  # caps and read them back from the normal output tree.
-  - pattern: "guides/results/"
-    unset: [PYAUTO_TEST_MODE]
+  # (guides/results/ formerly unset PYAUTO_TEST_MODE here; that intent now
+  # lives in-file as '# ENV: real_search' declarations on the scripts, which
+  # apply in every profile — the override became redundant.)
   #
   # fits_make / png_make produce .fits / .png outputs from real fits, so they
   # need PYAUTO_FAST_PLOTS forced off (it would otherwise close every figure

--- a/config/build/profile_smoke.yaml
+++ b/config/build/profile_smoke.yaml
@@ -21,33 +21,21 @@ defaults:
   MPLCONFIGDIR: "/tmp/matplotlib"           # Writable config dir for matplotlib
 
 overrides:
-  # start_here scripts load real FITS data that breaks with small datasets
-  - pattern: "imaging/start_here"
-    unset: [PYAUTO_SMALL_DATASETS]
-  - pattern: "interferometer/start_here"
-    unset: [PYAUTO_SMALL_DATASETS]
-  - pattern: "group/start_here"
-    unset: [PYAUTO_SMALL_DATASETS]
-  - pattern: "multi/start_here"
-    unset: [PYAUTO_SMALL_DATASETS]
-  # Non-simulator scripts that load committed FITS data need full-size
-  # datasets to avoid shape mismatch with pre-existing 100x100 data.
-  # Simulators run first and regenerate data at the capped size, but
-  # scripts using the old `if not dataset_path.exists()` pattern skip
-  # re-simulation when data already exists.
-  - pattern: "guides/"
-    unset: [PYAUTO_SMALL_DATASETS]
+  # The */start_here and guides/ PYAUTO_SMALL_DATASETS unsets migrated to
+  # in-file `# ENV: full_datasets` declarations on each matched script, and
+  # the PYAUTO_TEST_MODE / PYAUTO_FAST_PLOTS unsets below to `# ENV:
+  # real_search` / `# ENV: real_plots` — #187 Stage 2. The non-declarable
+  # PYAUTO_SKIP_* vars remain here.
   # guides/results/start_here.py must produce real samples so the example
   # scripts that read from `output/results_folder` afterwards
   # (data_fitting, queries, models, samples_via_aggregator) find a
   # non-empty aggregator. Covers all scripts under guides/results/.
+  # (PYAUTO_TEST_MODE moved to `# ENV: real_search`.)
   - pattern: "guides/results/"
-    unset: [PYAUTO_TEST_MODE, PYAUTO_SKIP_FIT_OUTPUT]
+    unset: [PYAUTO_SKIP_FIT_OUTPUT]
   # fits_make / png_make produce .fits / .png outputs from real fits, so they need
-  # visualization turned on AND PYAUTO_FAST_PLOTS turned off (the latter would
-  # close every figure without saving via the subplot_save / save_figure short-circuit
-  # in autoarray/plot/utils.py).
+  # visualization turned on. (PYAUTO_FAST_PLOTS moved to `# ENV: real_plots`.)
   - pattern: fits_make
-    unset: [PYAUTO_SKIP_VISUALIZATION, PYAUTO_FAST_PLOTS]
+    unset: [PYAUTO_SKIP_VISUALIZATION]
   - pattern: png_make
-    unset: [PYAUTO_SKIP_VISUALIZATION, PYAUTO_FAST_PLOTS]
+    unset: [PYAUTO_SKIP_VISUALIZATION]

--- a/scripts/group/start_here.py
+++ b/scripts/group/start_here.py
@@ -56,6 +56,9 @@ The code below sets up your environment if you are using Google Colab, including
 files required to run the notebook. If you are running this script not in Colab (e.g. locally on your own computer),
 running the code will still check correctly that your environment is set up and ready to go.
 """
+# ENV: full_datasets
+# start_here loads real full-resolution FITS data; SMALL_DATASETS would
+# break the committed data/mask shapes.
 
 import subprocess
 import sys

--- a/scripts/guides/advanced/add_a_profile.py
+++ b/scripts/guides/advanced/add_a_profile.py
@@ -38,6 +38,9 @@ custom profile without needing to dive deeply into the **PyAutoLens** codebase.
 That said, we still recommend exploring the source code to better understand how
 everything fits together.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/advanced/custom_analysis.py
+++ b/scripts/guides/advanced/custom_analysis.py
@@ -61,6 +61,9 @@ the **PyAutoLens** source code.
 
 We still recommend you take a look to see how things are structured!
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/advanced/multi_plane.py
+++ b/scripts/guides/advanced/multi_plane.py
@@ -34,6 +34,9 @@ To illustrate multi-plane ray-tracing, we first set up a simple lens system, usi
 We'll make things simple and assume 3 galaxies at redshifts 0.5, 1.0 and 2.0. We'll use a singular isothermal sphere
 for each galaxy's mass profile.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/advanced/over_sampling.py
+++ b/scripts/guides/advanced/over_sampling.py
@@ -43,6 +43,9 @@ __Contents__
 - **Pixelization:** Source galaxies can be reconstructed using pixelizations, which discretize the source's light onto.
 
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/advanced/over_sampling_chaining.py
+++ b/scripts/guides/advanced/over_sampling_chaining.py
@@ -37,6 +37,9 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `guides/modeling/chaining.ipynb` notebook.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/advanced/potential_correction.py
+++ b/scripts/guides/advanced/potential_correction.py
@@ -45,6 +45,9 @@ __Contents__
 - **Iterative Fit:** Refine the corrections with the iterative Levenberg-Marquardt engine `IterFitDpsiSrcImaging`.
 - **Evidence Sampling:** Sample the regularization hyper-parameters with a non-linear search via `DpsiSrcInvAnalysis`.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/guides/coolest_interop.py
+++ b/scripts/guides/coolest_interop.py
@@ -42,6 +42,9 @@ The exported `theta_E` is the mass profile's parameter in the COOLEST convention
 Einstein radius (e.g. the effective radius of the area within the tangential critical curve, used by the
 Euclid DR1 catalogue), which depends on all profiles in the model including external shear.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/data_structures.py
+++ b/scripts/guides/data_structures.py
@@ -34,6 +34,9 @@ arc seconds, luminosities in electrons per second and mass quantities (e.g. conv
 The guide `units_and_cosmology.ipynb` illustrates how to convert these quantities to physical units like
 kiloparsecs, magnitudes and solar masses.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/galaxies.py
+++ b/scripts/guides/galaxies.py
@@ -45,6 +45,9 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `results/start_here.ipynb` notebook.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/hpc/example_cpu.py
+++ b/scripts/guides/hpc/example_cpu.py
@@ -37,6 +37,9 @@ __Contents__
 - **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
 
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 # %%
 """

--- a/scripts/guides/lens_calc.py
+++ b/scripts/guides/lens_calc.py
@@ -57,6 +57,9 @@ unmasked data points.
 
 These are documented fully in the ``autolens_workspace/*/guides/data_structures.ipynb`` guide.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/modeling/advanced/expectation_propagation.py
+++ b/scripts/guides/modeling/advanced/expectation_propagation.py
@@ -38,6 +38,9 @@ The dataset fitted in this example script is simulated imaging data of a sample 
 This data is not automatically provided with the autogalaxy workspace, and must be first simulated by running the
 script `autolens_workspace/scripts/advanced/graphical/simulator/samples/simple__no_lens_light.py`.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/modeling/advanced/graphical.py
+++ b/scripts/guides/modeling/advanced/graphical.py
@@ -44,6 +44,9 @@ __Contents__
 - **Wrap Up:** Summary of the script and next steps.
 
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/modeling/advanced/hierarchical.py
+++ b/scripts/guides/modeling/advanced/hierarchical.py
@@ -36,6 +36,9 @@ __Contents__
 - **Wrap Up:** Summary of the script and next steps.
 
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/modeling/bug_fix.py
+++ b/scripts/guides/modeling/bug_fix.py
@@ -38,6 +38,9 @@ __Trouble Shooting__
 If you still cannot get parallelization to work, please ask to be added to the SLACK
 channel (by emailing me https://github.com/Jammy2211), where we will be able to provide support.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 
 def fit():

--- a/scripts/guides/modeling/chaining.py
+++ b/scripts/guides/modeling/chaining.py
@@ -49,6 +49,9 @@ to pass information between searches as well as tools for customizing prior pass
 
 There are examples throughout the workspace where search chaining improves and helps automate lens modeling.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/modeling/cookbook.py
+++ b/scripts/guides/modeling/cookbook.py
@@ -31,6 +31,9 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `modeling/start_here.ipynb` notebook.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/modeling/customize.py
+++ b/scripts/guides/modeling/customize.py
@@ -15,6 +15,9 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `modeling/start_here.ipynb` notebook.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/modeling/searches.py
+++ b/scripts/guides/modeling/searches.py
@@ -35,6 +35,9 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `modeling/start_here.ipynb` notebook.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/modeling/slam_start_here.py
+++ b/scripts/guides/modeling/slam_start_here.py
@@ -119,6 +119,9 @@ Each SLaM pipeline is implemented as a Python function below (e.g. `source_lp`, 
 documentation string above each function describing the pipeline in detail. The full pipeline is run at the
 bottom of the script.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/plot/advanced/plotters_double_einstein_ring.py
+++ b/scripts/guides/plot/advanced/plotters_double_einstein_ring.py
@@ -25,6 +25,9 @@ __Contents__
 - **Pixelized Source Reconstruction:** Now set up a double Einstein ring fit using pixelized source reconstructions.
 - **Inversion:** The inversion is computed directly from a `Tracer` using `TracerToInversion`.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/plot/advanced/plotters_pixelization.py
+++ b/scripts/guides/plot/advanced/plotters_pixelization.py
@@ -26,6 +26,9 @@ __Contents__
 - **Mapper Galaxy Dict:** The mapper galaxy dict maps each mapper to its corresponding galaxy.
 - **Fit Interferometer:** A fit to an interferometer dataset with a pixelized source is plotted with.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/plot/examples/mat_plot.py
+++ b/scripts/guides/plot/examples/mat_plot.py
@@ -31,6 +31,9 @@ __Contents__
 - **Log10:** Many lensing quantities (images, convergence, potential) span many orders of magnitude and are.
 - **Config Defaults:** All default values (colormaps, tick sizes, label fonts, etc.) are configured via the config files.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/plot/examples/plotters.py
+++ b/scripts/guides/plot/examples/plotters.py
@@ -40,6 +40,9 @@ __Setup__
 
 Set up standard objects used throughout this example.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/plot/examples/searches.py
+++ b/scripts/guides/plot/examples/searches.py
@@ -32,6 +32,9 @@ __Setup__
 To illustrate plotting, we require standard objects like a dataset and model which we will perform quick model-fits to
 for illustration.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/plot/examples/visuals.py
+++ b/scripts/guides/plot/examples/visuals.py
@@ -26,6 +26,9 @@ __Contents__
 - **Mass Profile Centres:** Mass profile centres can be extracted and overlaid in the same way.
 - **Combined Overlays:** `lines=` and `positions=` can be used together on the same plot.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/plot/start_here.py
+++ b/scripts/guides/plot/start_here.py
@@ -20,6 +20,9 @@ __Contents__
 - **Config Defaults:** All default plotting values are configured via config files in.
 - **Overlays:** Overlays are added to plots using the `lines=` and `positions=` keyword arguments.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/point_source_pairing.py
+++ b/scripts/guides/point_source_pairing.py
@@ -109,6 +109,9 @@ __Demonstration__
 The code below builds a toy under- and over-predicting fit so the policies are visible in numbers,
 using a mock solver so it runs in seconds.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 import numpy as np
 

--- a/scripts/guides/profiles/light.py
+++ b/scripts/guides/profiles/light.py
@@ -62,6 +62,9 @@ documented there under the `Standard [ag.lp]` autosummary, and so on for `al.lp_
 `al.lp_operated`, `al.lp_basis`.  Note that the API reference uses the `ag.*` namespace
 labels because the classes are defined in PyAutoGalaxy and re-exported here.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 # from autolens import setup_notebook; setup_notebook()
 

--- a/scripts/guides/profiles/light_and_mass_profiles.py
+++ b/scripts/guides/profiles/light_and_mass_profiles.py
@@ -68,6 +68,9 @@ combined profiles in `al.lmp.*` and `al.lmp_linear.*` are not yet documented on 
 reference page — refer to the source under
 `autogalaxy/profiles/light_and_mass_profiles.py` for the full list.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 # from autolens import setup_notebook; setup_notebook()
 

--- a/scripts/guides/profiles/mass.py
+++ b/scripts/guides/profiles/mass.py
@@ -66,6 +66,9 @@ The autosummary on that page is the authoritative list of every public mass-prof
 Note that the reference uses the `ag.mp` namespace label because the classes are defined in
 PyAutoGalaxy and re-exported here as `al.mp`.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 # from autolens import setup_notebook; setup_notebook()
 

--- a/scripts/guides/results/_quick_fit.py
+++ b/scripts/guides/results/_quick_fit.py
@@ -17,6 +17,11 @@ search is hard-capped at ``n_like_max=300`` likelihood evaluations rather
 than running to convergence. This produces a shallow but valid posterior
 fast enough to fit inside the per-script CI timeout.
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 import shutil
 import sys

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -30,6 +30,11 @@ The only entries that needs changing are:
 Quantities specific to an interfometer, for example its uv-wavelengths real space mask, are accessed using the same API
 (e.g. `values("dataset.uv_wavelengths")` and `.values{"dataset.real_space_mask")).
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/results/aggregator/galaxies_fits.py
+++ b/scripts/guides/results/aggregator/galaxies_fits.py
@@ -49,6 +49,11 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `results/start_here.ipynb` notebook.
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/results/aggregator/interferometer.py
+++ b/scripts/guides/results/aggregator/interferometer.py
@@ -2,6 +2,11 @@
 This script still needs writing, I have kept some notes on questions asked by users which may help you...
 
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 """
  > For interferometric data, which units PyAutoLens uses for brightness? I think they are in Jy/arcsec^2 (?) since 

--- a/scripts/guides/results/aggregator/models.py
+++ b/scripts/guides/results/aggregator/models.py
@@ -16,6 +16,11 @@ __Contents__
 - **Einstein Mass Example:** Each tracer has the information we need to compute the Einstein mass of a model.
 
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -18,6 +18,11 @@ __Contents__
 - **Logic:** Advanced queries can be constructed using logic, for example we below we combine the two queries.
 
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -38,6 +38,11 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `results/start_here.ipynb` notebook.
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -46,6 +46,11 @@ A fraction of this example repeats the API for manipulating samples given in the
 This is done so users can directly copy and paste Python code which loads results from the database and manipulates
 the samples.
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/results/database/start_here.py
+++ b/scripts/guides/results/database/start_here.py
@@ -37,6 +37,11 @@ The search fits each lens with:
  - An `Isothermal` `MassProfile` for the lens galaxy's mass.
  - An `Sersic` `LightProfile` for the source galaxy's light.
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/results/latent_variables.py
+++ b/scripts/guides/results/latent_variables.py
@@ -24,6 +24,11 @@ __Contents__
  - Extending with a Custom Latent: Subclass ``al.AnalysisImaging`` to add lens-mass derived quantities.
  - Contributing Upstream: When your custom latent is general enough, promote it to the library.
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 # from autolens import setup_notebook; setup_notebook()
 

--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -79,6 +79,11 @@ __Contents__
 **Linear Light Profiles / Basis Objects:** Specific functionality for linear light profiles and basis functions.
 **Pixelization:** Pixelized source reconstructions on a Voronoi mesh.
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 from autolens import from_json

--- a/scripts/guides/results/workflow/csv_make.py
+++ b/scripts/guides/results/workflow/csv_make.py
@@ -58,6 +58,11 @@ because it is optimized for fast querying of results.
 See the package `results/database` for a full description of how to set up the database and the benefits it provides,
 especially if loading results from hard-disk is slow.
 """
+# ENV: full_datasets real_search
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/results/workflow/fits_make.py
+++ b/scripts/guides/results/workflow/fits_make.py
@@ -69,6 +69,13 @@ because it is optimized for fast querying of results.
 See the package `results/database` for a full description of how to set up the database and the benefits it provides,
 especially if loading results from hard-disk is slow.
 """
+# ENV: full_datasets real_search real_plots
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
+# Produces real .fits outputs; FAST_PLOTS would close figures
+# without saving via the subplot_save short-circuit.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/results/workflow/png_make.py
+++ b/scripts/guides/results/workflow/png_make.py
@@ -70,6 +70,13 @@ because it is optimized for fast querying of results.
 See the package `results/database` for a full description of how to set up the database and the benefits it provides,
 especially if loading results from hard-disk is slow.
 """
+# ENV: full_datasets real_search real_plots
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
+# Results guides must produce real (reduced) samples so downstream
+# aggregator reads (data_fitting, queries, ...) are non-empty.
+# Produces real .png outputs; FAST_PLOTS would close figures
+# without saving via the subplot_save short-circuit.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/tracer.py
+++ b/scripts/guides/tracer.py
@@ -64,6 +64,9 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `results/start_here.ipynb` notebook.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/units/cosmology.py
+++ b/scripts/guides/units/cosmology.py
@@ -22,6 +22,9 @@ __Errors__
 To produce errors on unit converted quantities, you`ll may need to perform marginalization over samples of these
 converted quantities (see `results/aggregator/samples.ipynb`).
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/units/flux.py
+++ b/scripts/guides/units/flux.py
@@ -40,6 +40,9 @@ the raw measurements of light received by a telescope into meaningful values of 
 The conversions below all require a zero point, which is typically provided in the documentation of the telescope or
 instrument that was used to observe the data.
 """
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 

--- a/scripts/guides/units/mass_to_light_ratio_units.py
+++ b/scripts/guides/units/mass_to_light_ratio_units.py
@@ -1,3 +1,6 @@
+# ENV: full_datasets
+# Guides load committed full-resolution FITS; SMALL_DATASETS would
+# mismatch the pre-existing 100x100 data shape.
 import numpy as np
 import autolens as al
 import autogalaxy as ag

--- a/scripts/imaging/start_here.py
+++ b/scripts/imaging/start_here.py
@@ -55,6 +55,9 @@ The code below sets up your environment if you are using Google Colab, including
 files required to run the notebook. If you are running this script not in Colab (e.g. locally on your own computer),
 running the code will still check correctly that your environment is set up and ready to go.
 """
+# ENV: full_datasets
+# start_here loads real full-resolution FITS data; SMALL_DATASETS would
+# break the committed data/mask shapes.
 
 import subprocess
 import sys

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -86,6 +86,9 @@ The code below sets up your environment if you are using Google Colab, including
 files required to run the notebook. If you are running this script not in Colab (e.g. locally on your own computer),
 running the code will still check correctly that your environment is set up and ready to go.
 """
+# ENV: full_datasets
+# start_here loads real full-resolution FITS data; SMALL_DATASETS would
+# break the committed data/mask shapes.
 
 import subprocess
 import sys

--- a/scripts/multi/start_here.py
+++ b/scripts/multi/start_here.py
@@ -59,6 +59,9 @@ The code below sets up your environment if you are using Google Colab, including
 files required to run the notebook. If you are running this script not in Colab (e.g. locally on your own computer),
 running the code will still check correctly that your environment is set up and ready to go.
 """
+# ENV: full_datasets
+# start_here loads real full-resolution FITS data; SMALL_DATASETS would
+# break the committed data/mask shapes.
 
 import subprocess
 import sys


### PR DESCRIPTION
## Overview

Phase 1b migration (PyAutoLabs/PyAutoHands#187; mechanism PR: PyAutoLabs/PyAutoHands#188 — merge that first). Per-script env requirements move from pattern-keyed override blocks in `config/build/profile_smoke.yaml` into the scripts themselves as `# ENV: <tokens>` declarations, so a moved or renamed script carries its env config with it instead of silently orphaning an override. Each override's rationale comment moved into the script beside its declaration. Overrides that cannot be expressed as declarations (`set:` clauses, non-declarable vars, or `DISABLE_JAX` unsets matching non-JAX-marked scripts) remain pattern-keyed by design.

## Scripts Changed

- `config/build/profile_smoke.yaml` — migrated override blocks deleted (mixed overrides shrunk to their non-declarable remainder).
- `scripts/**` — matched scripts gain a one-line `# ENV:` declaration + condensed rationale comment. (User-workspace PRs also touch `config/build/profile_release.yaml` where a now-redundant `guides/results/` override was removed — the declaration covers it in every profile.)

Per-repo detail is in the PR's file list; the per-repo migration table (migrated / split / kept, with reasons) is on PyAutoLabs/PyAutoHands#187.

## Verification

- **Smoke resolution byte-identical to HEAD** for every script in this repo (empty-base resolved-env diff, old profile vs new profile + declarations).
- Release diffs (where a release profile exists) exclusively in the reader-verified `"0"` → absent equivalence class (absent ≡ "0"/off for all four managed vars — file:line evidence in PyAutoHands `docs/env_profile_redesign.md` §10).
- Validator: **0 errors with all strict flags on, including `--strict-declarations`**.

## Ship note

Shipped under human-acknowledged Heart YELLOW: `workspace validation not passing (13 failed, 2026-07-21T19-05-22Z)`; `33 stale parked script(s)` — both pre-existing and unrelated.

Linked issue: PyAutoLabs/PyAutoHands#187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRQH5HrmMPfpWkmfh3ysJb
