### PR TITLE
refactor: env declarations move to __Env__ docstring sections

### DIFF
--- a/scripts/group/start_here.py
+++ b/scripts/group/start_here.py
@@ -56,9 +56,6 @@ The code below sets up your environment if you are using Google Colab, including
 files required to run the notebook. If you are running this script not in Colab (e.g. locally on your own computer),
 running the code will still check correctly that your environment is set up and ready to go.
 """
-# ENV: full_datasets
-# start_here loads real full-resolution FITS data; SMALL_DATASETS would
-# break the committed data/mask shapes.
 
 import subprocess
 import sys
@@ -408,4 +405,18 @@ The following locations of the workspace are good places to checkout next:
 - `autolens_workspace/guides/results`: How to load and analyze the results of your lens model fits, including tools for large samples.
 - `autolens_workspace/guides`: A complete description of the API and information on lensing calculations and units.
 - `autolens_workspace/group/features`: A description of advanced features for lens modeling, for example pixelized source reconstructions, read this once you're confident with the basics!
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+start_here loads real full-resolution FITS data; SMALL_DATASETS would break
+the committed data/mask shapes.
+
+ENV: full_datasets
 """

--- a/scripts/guides/advanced/add_a_profile.py
+++ b/scripts/guides/advanced/add_a_profile.py
@@ -38,9 +38,6 @@ custom profile without needing to dive deeply into the **PyAutoLens** codebase.
 That said, we still recommend exploring the source code to better understand how
 everything fits together.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -671,4 +668,18 @@ Show how to wrap existing profiles with physical units?
 __Light Profiles__
 
 Pretty much the same but need to add text.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/advanced/custom_analysis.py
+++ b/scripts/guides/advanced/custom_analysis.py
@@ -61,9 +61,6 @@ the **PyAutoLens** source code.
 
 We still recommend you take a look to see how things are structured!
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -604,4 +601,18 @@ I will extend this guide to include the following in the next few days:
  the interpretation of results.
  - How to output results to hard-disk in a format that can be loaded into the **PyAutoLens** database.
  
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/advanced/multi_plane.py
+++ b/scripts/guides/advanced/multi_plane.py
@@ -34,9 +34,6 @@ To illustrate multi-plane ray-tracing, we first set up a simple lens system, usi
 We'll make things simple and assume 3 galaxies at redshifts 0.5, 1.0 and 2.0. We'll use a singular isothermal sphere
 for each galaxy's mass profile.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -702,4 +699,18 @@ time, we use a sample of five cluster strong lenses to measure the values of cos
 with those from classical probes. In order to assess the degeneracies and the effectiveness of strong-lensing 
 cosmography in constraining the background geometry of the Universe, we adopt four cosmological scenarios. We find 
 good constraining power on the total matter density of the Universe ($Ω_{\rm m}$) and the equation of state of the dark e… Show more
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/advanced/over_sampling.py
+++ b/scripts/guides/advanced/over_sampling.py
@@ -43,9 +43,6 @@ __Contents__
 - **Pixelization:** Source galaxies can be reconstructed using pixelizations, which discretize the source's light onto.
 
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -558,4 +555,18 @@ The numerical verification of all of the above lives in
 brute-force reference calculations.
 
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/advanced/over_sampling_chaining.py
+++ b/scripts/guides/advanced/over_sampling_chaining.py
@@ -37,9 +37,6 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `guides/modeling/chaining.ipynb` notebook.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -295,4 +292,18 @@ print(result_2.info)
 
 """
 Fin.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/advanced/potential_correction.py
+++ b/scripts/guides/advanced/potential_correction.py
@@ -45,9 +45,6 @@ __Contents__
 - **Iterative Fit:** Refine the corrections with the iterative Levenberg-Marquardt engine `IterFitDpsiSrcImaging`.
 - **Evidence Sampling:** Sample the regularization hyper-parameters with a non-linear search via `DpsiSrcInvAnalysis`.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 # %matplotlib inline
 # from pyprojroot import here
@@ -335,4 +332,18 @@ hyper-parameters — with all linear algebra available under numpy or JAX throug
 
 If you use this functionality, please cite Cao et al. 2025
 (https://github.com/caoxiaoyue/potential_correction_paper) alongside PyAutoLens.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/coolest_interop.py
+++ b/scripts/guides/coolest_interop.py
@@ -42,9 +42,6 @@ The exported `theta_E` is the mass profile's parameter in the COOLEST convention
 Einstein radius (e.g. the effective radius of the area within the tangential critical curve, used by the
 Euclid DR1 catalogue), which depends on all profiles in the model including external shear.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -140,4 +137,18 @@ Light: `Sersic` / `SersicSph`. Mass: `Isothermal` / `IsothermalSph` (SIE), `Powe
 an error naming the profile.
 
 Fin.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/data_structures.py
+++ b/scripts/guides/data_structures.py
@@ -34,9 +34,6 @@ arc seconds, luminosities in electrons per second and mass quantities (e.g. conv
 The guide `units_and_cosmology.ipynb` illustrates how to convert these quantities to physical units like
 kiloparsecs, magnitudes and solar masses.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -506,4 +503,18 @@ Plotting and `.fits` writers handle the conversion transparently.
 
 """
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/galaxies.py
+++ b/scripts/guides/galaxies.py
@@ -45,9 +45,6 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `results/start_here.ipynb` notebook.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -275,4 +272,18 @@ The full deep-dive on the bound-method vs traced-argument trade-off,
 cache-identity footguns, and the `@jax.jit + xp=jnp` pairing rule lives
 in `scripts/guides/lens_calc.py`. The `.array` host-transfer mechanics
 live in `scripts/guides/data_structures.py`.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/hpc/example_cpu.py
+++ b/scripts/guides/hpc/example_cpu.py
@@ -37,9 +37,6 @@ __Contents__
 - **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
 
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 # %%
 """
@@ -384,3 +381,17 @@ We begin the model-fit by passing the model and analysis object to the non-linea
 for on-the-fly visualization and results).
 """
 result = search.fit(model=model, analysis=analysis)
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
+"""

--- a/scripts/guides/lens_calc.py
+++ b/scripts/guides/lens_calc.py
@@ -57,9 +57,6 @@ unmasked data points.
 
 These are documented fully in the ``autolens_workspace/*/guides/data_structures.ipynb`` guide.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -616,4 +613,18 @@ For further reading:
 - ``guides/data_structures.py`` — the ``Array2D``, ``Grid2D`` and ``VectorYX2D`` data structures.
 
 The `LensCalc` class is also available via `al.LensCalc` — it lives in ``PyAutoGalaxy/autogalaxy/operate/lens_calc.py``.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/modeling/advanced/expectation_propagation.py
+++ b/scripts/guides/modeling/advanced/expectation_propagation.py
@@ -38,9 +38,6 @@ The dataset fitted in this example script is simulated imaging data of a sample 
 This data is not automatically provided with the autogalaxy workspace, and must be first simulated by running the
 script `autolens_workspace/scripts/advanced/graphical/simulator/samples/simple__no_lens_light.py`.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -373,3 +370,17 @@ as a key to the `MeanField.mean` dictionary to print the estimated value of the 
 # """
 # print(f"Centre SD/sqrt(variance) = {mean_field.scale[prior]}")
 # print()
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
+"""

--- a/scripts/guides/modeling/advanced/graphical.py
+++ b/scripts/guides/modeling/advanced/graphical.py
@@ -44,9 +44,6 @@ __Contents__
 - **Wrap Up:** Summary of the script and next steps.
 
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -274,4 +271,18 @@ inference.
 This example used a simple shared parameter (the Hubble constant) across multiple lenses. The same framework can be
 extended to far more complex models, with many shared or linked parameters, enabling powerful hierarchical and
 population-level inference for large lens samples.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/modeling/advanced/hierarchical.py
+++ b/scripts/guides/modeling/advanced/hierarchical.py
@@ -36,9 +36,6 @@ __Contents__
 - **Wrap Up:** Summary of the script and next steps.
 
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -318,4 +315,18 @@ us to fit graphs with hundreds of components and tens of thousands of parameters
 optimizations.
 
 This makes hierarchical graphical modeling **scalable to the largest datasets and most complex models.**
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/modeling/bug_fix.py
+++ b/scripts/guides/modeling/bug_fix.py
@@ -38,9 +38,6 @@ __Trouble Shooting__
 If you still cannot get parallelization to work, please ask to be added to the SLACK
 channel (by emailing me https://github.com/Jammy2211), where we will be able to provide support.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 
 def fit():
@@ -186,3 +183,17 @@ This small change in how the code is run fixes parallelization issues.
 """
 if __name__ == "__main__":
     fit()
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
+"""

--- a/scripts/guides/modeling/chaining.py
+++ b/scripts/guides/modeling/chaining.py
@@ -49,9 +49,6 @@ to pass information between searches as well as tools for customizing prior pass
 
 There are examples throughout the workspace where search chaining improves and helps automate lens modeling.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -386,4 +383,18 @@ If the prior config file had specified that we use an relative value of 0.8, the
 mean=4.0 and sigma = 4.0 * 0.8 = 3.2.
 
 And with that, we're done. Chaining priors is a bit of an art form, but one that works really well. 
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/modeling/cookbook.py
+++ b/scripts/guides/modeling/cookbook.py
@@ -31,9 +31,6 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `modeling/start_here.ipynb` notebook.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -434,4 +431,18 @@ https://pyautofit.readthedocs.io/en/latest/cookbooks/multi_level_model.html
 __Wrap Up__
 
 This cookbook shows how to compose simple lens models using the `af.Model()` and `af.Collection()` objects.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/modeling/customize.py
+++ b/scripts/guides/modeling/customize.py
@@ -15,9 +15,6 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `modeling/start_here.ipynb` notebook.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -273,4 +270,18 @@ analysis = al.AnalysisImaging(
 
 """
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/modeling/searches.py
+++ b/scripts/guides/modeling/searches.py
@@ -35,9 +35,6 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `modeling/start_here.ipynb` notebook.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -335,4 +332,18 @@ The **PyAutoFit** search cookbook documents all searches that are available, inc
 and provides the code you can easily copy and paste to use these methods.
 
 https://pyautofit.readthedocs.io/en/latest/cookbooks/search.html
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/modeling/slam_start_here.py
+++ b/scripts/guides/modeling/slam_start_here.py
@@ -119,9 +119,6 @@ Each SLaM pipeline is implemented as a Python function below (e.g. `source_lp`, 
 documentation string above each function describing the pipeline in detail. The full pipeline is run at the
 bottom of the script.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -640,4 +637,18 @@ mass_result = mass_total(
 
 """
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/plot/advanced/plotters_double_einstein_ring.py
+++ b/scripts/guides/plot/advanced/plotters_double_einstein_ring.py
@@ -25,9 +25,6 @@ __Contents__
 - **Pixelized Source Reconstruction:** Now set up a double Einstein ring fit using pixelized source reconstructions.
 - **Inversion:** The inversion is computed directly from a `Tracer` using `TracerToInversion`.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -215,4 +212,18 @@ aplt.plot_array(
 
 """
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/plot/advanced/plotters_pixelization.py
+++ b/scripts/guides/plot/advanced/plotters_pixelization.py
@@ -26,9 +26,6 @@ __Contents__
 - **Mapper Galaxy Dict:** The mapper galaxy dict maps each mapper to its corresponding galaxy.
 - **Fit Interferometer:** A fit to an interferometer dataset with a pixelized source is plotted with.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -266,4 +263,18 @@ aplt.plot_array(
 
 """
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/plot/examples/mat_plot.py
+++ b/scripts/guides/plot/examples/mat_plot.py
@@ -31,9 +31,6 @@ __Contents__
 - **Log10:** Many lensing quantities (images, convergence, potential) span many orders of magnitude and are.
 - **Config Defaults:** All default values (colormaps, tick sizes, label fonts, etc.) are configured via the config files.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -156,4 +153,18 @@ This allows project-wide defaults to be set without changing code.
 
 """
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/plot/examples/plotters.py
+++ b/scripts/guides/plot/examples/plotters.py
@@ -40,9 +40,6 @@ __Setup__
 
 Set up standard objects used throughout this example.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -394,4 +391,18 @@ aplt.subplot_fit_point(fit=fit)
 
 """
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/plot/examples/searches.py
+++ b/scripts/guides/plot/examples/searches.py
@@ -32,9 +32,6 @@ __Setup__
 To illustrate plotting, we require standard objects like a dataset and model which we will perform quick model-fits to
 for illustration.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -857,4 +854,18 @@ plt.close()
 Note that the models do not need to be the same to make the plots above.
 
 GetDist will clever use the `names` of the parameters to combine the parameters into customizeable PDF plots.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/plot/examples/visuals.py
+++ b/scripts/guides/plot/examples/visuals.py
@@ -26,9 +26,6 @@ __Contents__
 - **Mass Profile Centres:** Mass profile centres can be extracted and overlaid in the same way.
 - **Combined Overlays:** `lines=` and `positions=` can be used together on the same plot.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -267,4 +264,18 @@ aplt.plot_array(
 
 """
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/plot/start_here.py
+++ b/scripts/guides/plot/start_here.py
@@ -20,9 +20,6 @@ __Contents__
 - **Config Defaults:** All default plotting values are configured via config files in.
 - **Overlays:** Overlays are added to plots using the `lines=` and `positions=` keyword arguments.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -218,4 +215,18 @@ aplt.subplot_fit_imaging(fit=fit)
 """
 The search plotting functions (`aplt.corner_anesthetic`, `aplt.corner_cornerpy`, etc.) provide
 visualization of non-linear search results -- see `scripts/guides/plot/examples/searches.py`.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/point_source_pairing.py
+++ b/scripts/guides/point_source_pairing.py
@@ -109,9 +109,6 @@ __Demonstration__
 The code below builds a toy under- and over-predicting fit so the policies are visible in numbers,
 using a mock solver so it runs in seconds.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 import numpy as np
 
@@ -184,4 +181,18 @@ print(f"  chi_squared = {float(fit.chi_squared):.4f}")
 """
 Finished. For the production-scale picture — real solver, multi-plane cluster tracer, timings —
 see ``scripts/cluster/likelihood_function.py`` and the profiling breakdowns referenced above.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/profiles/light.py
+++ b/scripts/guides/profiles/light.py
@@ -62,9 +62,6 @@ documented there under the `Standard [ag.lp]` autosummary, and so on for `al.lp_
 `al.lp_operated`, `al.lp_basis`.  Note that the API reference uses the `ag.*` namespace
 labels because the classes are defined in PyAutoGalaxy and re-exported here.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 # from autolens import setup_notebook; setup_notebook()
 
@@ -648,4 +645,18 @@ subpackages handle the family-specific workflows referenced throughout this guid
 For the mass-profile counterpart of this guide, see `scripts/guides/profiles/mass.py`
 (when available).  For a full walk-through of how light and mass profiles are combined in
 the `Tracer` to produce lensed images, see `scripts/guides/tracer.py`.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/profiles/light_and_mass_profiles.py
+++ b/scripts/guides/profiles/light_and_mass_profiles.py
@@ -68,9 +68,6 @@ combined profiles in `al.lmp.*` and `al.lmp_linear.*` are not yet documented on 
 reference page — refer to the source under
 `autogalaxy/profiles/light_and_mass_profiles.py` for the full list.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 # from autolens import setup_notebook; setup_notebook()
 
@@ -753,4 +750,18 @@ For the next step into actual lens modelling, see `scripts/imaging/modeling/star
 (strong-lens fit end-to-end) and the topic-specific feature packages under
 `scripts/imaging/features/`.  The SLaM pipeline guide (`scripts/guides/modeling/slam_start_here.py`)
 shows the production decomposed-lens workflow built on these profiles.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/profiles/mass.py
+++ b/scripts/guides/profiles/mass.py
@@ -66,9 +66,6 @@ The autosummary on that page is the authoritative list of every public mass-prof
 Note that the reference uses the `ag.mp` namespace label because the classes are defined in
 PyAutoGalaxy and re-exported here as `al.mp`.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 # from autolens import setup_notebook; setup_notebook()
 
@@ -628,4 +625,18 @@ profiles in an actual lens fit, the next step is `scripts/imaging/modeling/start
 which sets up an `AnalysisImaging` and runs a non-linear search end-to-end on a strong-lens
 dataset.  For a deeper walk-through of how mass profiles combine with light profiles in the
 `Tracer` to produce lensed images, see `scripts/guides/tracer.py`.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/results/_quick_fit.py
+++ b/scripts/guides/results/_quick_fit.py
@@ -17,11 +17,6 @@ search is hard-capped at ``n_like_max=300`` likelihood evaluations rather
 than running to convergence. This produces a shallow but valid posterior
 fast enough to fit inside the per-script CI timeout.
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 import shutil
 import sys
@@ -167,3 +162,19 @@ for unique_tag in [dataset_name, f"{dataset_name}_1"]:
     )
 
     search.fit(model=model, analysis=analysis)
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
+"""

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -30,11 +30,6 @@ The only entries that needs changing are:
 Quantities specific to an interfometer, for example its uv-wavelengths real space mask, are accessed using the same API
 (e.g. `values("dataset.uv_wavelengths")` and `.values{"dataset.real_space_mask")).
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -207,4 +202,20 @@ for fit_list_gen in fit_gen:  # 1 Dataset so just one fit
 
 """
 Finished.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
 """

--- a/scripts/guides/results/aggregator/galaxies_fits.py
+++ b/scripts/guides/results/aggregator/galaxies_fits.py
@@ -49,11 +49,6 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `results/start_here.ipynb` notebook.
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -258,4 +253,20 @@ __Wrap Up__
 
 We have learnt how to extract individual planes, galaxies, light and mass profiles from the tracer that results from
 a model-fit and use these objects to compute specific quantities of each component.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
 """

--- a/scripts/guides/results/aggregator/interferometer.py
+++ b/scripts/guides/results/aggregator/interferometer.py
@@ -2,11 +2,6 @@
 This script still needs writing, I have kept some notes on questions asked by users which may help you...
 
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 """
  > For interferometric data, which units PyAutoLens uses for brightness? I think they are in Jy/arcsec^2 (?) since 
@@ -37,4 +32,20 @@ harm either.
 One caveat may be magnifications. It could be that as you make the shape of the interpolation grid bigger, the
 magnification changes. I'm not sure on this but would advise you experiment to see if the magnifications 
 seem "stable" (assuming you are estimate a magnification at some point).
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
 """

--- a/scripts/guides/results/aggregator/models.py
+++ b/scripts/guides/results/aggregator/models.py
@@ -16,11 +16,6 @@ __Contents__
 - **Einstein Mass Example:** Each tracer has the information we need to compute the Einstein mass of a model.
 
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -238,4 +233,20 @@ for tracer_gen in tracer_list_gen:
 
 """
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
 """

--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -18,11 +18,6 @@ __Contents__
 - **Logic:** Advanced queries can be constructed using logic, for example we below we combine the two queries.
 
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -148,4 +143,20 @@ print(
 
 """
 Finished.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
 """

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -38,11 +38,6 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `results/start_here.ipynb` notebook.
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -610,4 +605,20 @@ print(samples.parameter_lists[0])
 
 """
 Fin.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
 """

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -46,11 +46,6 @@ A fraction of this example repeats the API for manipulating samples given in the
 This is done so users can directly copy and paste Python code which loads results from the database and manipulates
 the samples.
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -561,4 +556,20 @@ print(samples.parameter_lists[0])
 
 """
 Finished.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
 """

--- a/scripts/guides/results/database/start_here.py
+++ b/scripts/guides/results/database/start_here.py
@@ -37,11 +37,6 @@ The search fits each lens with:
  - An `Isothermal` `MassProfile` for the lens galaxy's mass.
  - An `Sersic` `LightProfile` for the source galaxy's light.
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -353,4 +348,20 @@ This example illustrates how to use the database.
 
 The API above can be combined with the `results/aggregator` scripts in order to use the database to load results and
 perform analysis on them.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
 """

--- a/scripts/guides/results/latent_variables.py
+++ b/scripts/guides/results/latent_variables.py
@@ -24,11 +24,6 @@ __Contents__
  - Extending with a Custom Latent: Subclass ``al.AnalysisImaging`` to add lens-mass derived quantities.
  - Contributing Upstream: When your custom latent is general enough, promote it to the library.
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 # from autolens import setup_notebook; setup_notebook()
 
@@ -294,4 +289,20 @@ Pipeline-specific latents that need non-standard kwargs (PSF-relative aperture f
 photometric quantities, multi-band colour terms) belong in your pipeline's local Analysis subclass. The Euclid
 pipeline (``euclid_strong_lens_modeling_pipeline/util.py``) demonstrates this — its FWHM aperture-flux latents
 stay pipeline-local and the rest inherit from the library.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
 """

--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -79,11 +79,6 @@ __Contents__
 **Linear Light Profiles / Basis Objects:** Specific functionality for linear light profiles and basis functions.
 **Pixelization:** Pixelized source reconstructions on a Voronoi mesh.
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 from autolens import from_json
@@ -625,4 +620,20 @@ The example script `autolens_workspace/*/features/pixelization.py` describes usi
 
 Therefore if your results contain a pixelization, checkout the example script above for a detailed description
 of how to use their results.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
 """

--- a/scripts/guides/results/workflow/csv_make.py
+++ b/scripts/guides/results/workflow/csv_make.py
@@ -58,11 +58,6 @@ because it is optimized for fast querying of results.
 See the package `results/database` for a full description of how to set up the database and the benefits it provides,
 especially if loading results from hard-disk is slow.
 """
-# ENV: full_datasets real_search
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -297,3 +292,19 @@ agg_csv.add_computed_column(
 )
 
 agg_csv.save(path=workflow_path / "csv_computed_columns.csv")
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty.
+
+ENV: full_datasets real_search
+"""

--- a/scripts/guides/results/workflow/fits_make.py
+++ b/scripts/guides/results/workflow/fits_make.py
@@ -69,13 +69,6 @@ because it is optimized for fast querying of results.
 See the package `results/database` for a full description of how to set up the database and the benefits it provides,
 especially if loading results from hard-disk is slow.
 """
-# ENV: full_datasets real_search real_plots
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
-# Produces real .fits outputs; FAST_PLOTS would close figures
-# without saving via the subplot_save short-circuit.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -298,4 +291,21 @@ which they can then extract and make together.
 __Path Navigation__
 
 Example combinig `fit.fits` from `source_lp[1]` and `mass_total[0]`.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty. Produces real .fits outputs; FAST_PLOTS would close
+figures without saving via the subplot_save short-circuit.
+
+ENV: full_datasets real_search real_plots
 """

--- a/scripts/guides/results/workflow/png_make.py
+++ b/scripts/guides/results/workflow/png_make.py
@@ -70,13 +70,6 @@ because it is optimized for fast querying of results.
 See the package `results/database` for a full description of how to set up the database and the benefits it provides,
 especially if loading results from hard-disk is slow.
 """
-# ENV: full_datasets real_search real_plots
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
-# Results guides must produce real (reduced) samples so downstream
-# aggregator reads (data_fitting, queries, ...) are non-empty.
-# Produces real .png outputs; FAST_PLOTS would close figures
-# without saving via the subplot_save short-circuit.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -264,4 +257,21 @@ which they can then extract and make together.
 __Path Navigation__
 
 Example combinng `subplot_fit.png` from `source_lp[1]` and `mass_total[0]`.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape. Results guides must produce real
+(reduced) samples so downstream aggregator reads (data_fitting, queries,
+...) are non-empty. Produces real .png outputs; FAST_PLOTS would close
+figures without saving via the subplot_save short-circuit.
+
+ENV: full_datasets real_search real_plots
 """

--- a/scripts/guides/tracer.py
+++ b/scripts/guides/tracer.py
@@ -64,9 +64,6 @@ __Start Here Notebook__
 
 If any code in this script is unclear, refer to the `results/start_here.ipynb` notebook.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -598,4 +595,18 @@ covers the `.array` host-transfer story.
 
 """
 Fin.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/units/cosmology.py
+++ b/scripts/guides/units/cosmology.py
@@ -22,9 +22,6 @@ __Errors__
 To produce errors on unit converted quantities, you`ll may need to perform marginalization over samples of these
 converted quantities (see `results/aggregator/samples.ipynb`).
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -278,3 +275,17 @@ The total mass of the convergence map is the sum of all these masses.
 print(
     f"Total mass in convergence map: {np.sum(convergence * critical_surface_density * pixel_area_kpc)} MSun"
 )
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
+"""

--- a/scripts/guides/units/flux.py
+++ b/scripts/guides/units/flux.py
@@ -40,9 +40,6 @@ the raw measurements of light received by a telescope into meaningful values of 
 The conversions below all require a zero point, which is typically provided in the documentation of the telescope or
 instrument that was used to observe the data.
 """
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 
 from autolens import jax_wrapper  # Sets JAX environment before other imports
 
@@ -299,4 +296,18 @@ populated with NaN and a single warning per process notes that the conversion wa
 unaffected.
 
 Finish.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
 """

--- a/scripts/guides/units/mass_to_light_ratio_units.py
+++ b/scripts/guides/units/mass_to_light_ratio_units.py
@@ -1,6 +1,3 @@
-# ENV: full_datasets
-# Guides load committed full-resolution FITS; SMALL_DATASETS would
-# mismatch the pre-existing 100x100 data shape.
 import numpy as np
 import autolens as al
 import autogalaxy as ag
@@ -124,3 +121,17 @@ if __name__ == "__main__":
     print(mass.mass_to_light_ratio)
     print("The total mass of this galaxy should be ~ 2.47 * 10^8")
     print(f"While the result of the light-trace-mass profile is {total_mass:.4e}")
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+Guides load committed full-resolution FITS; SMALL_DATASETS would mismatch
+the pre-existing 100x100 data shape.
+
+ENV: full_datasets
+"""

--- a/scripts/imaging/start_here.py
+++ b/scripts/imaging/start_here.py
@@ -55,9 +55,6 @@ The code below sets up your environment if you are using Google Colab, including
 files required to run the notebook. If you are running this script not in Colab (e.g. locally on your own computer),
 running the code will still check correctly that your environment is set up and ready to go.
 """
-# ENV: full_datasets
-# start_here loads real full-resolution FITS data; SMALL_DATASETS would
-# break the committed data/mask shapes.
 
 import subprocess
 import sys
@@ -587,4 +584,18 @@ The following locations of the workspace are good places to checkout next:
 - `autolens_workspace/guides/results`: How to load and analyze the results of your lens model fits, including tools for large samples.
 - `autolens_workspace/guides`: A complete description of the API and information on lensing calculations and units.
 - `autolens_workspace/imaging/features`: A description of advanced features for lens modeling, for example pixelized source reconstructions, read this once you're confident with the basics!
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+start_here loads real full-resolution FITS data; SMALL_DATASETS would break
+the committed data/mask shapes.
+
+ENV: full_datasets
 """

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -86,9 +86,6 @@ The code below sets up your environment if you are using Google Colab, including
 files required to run the notebook. If you are running this script not in Colab (e.g. locally on your own computer),
 running the code will still check correctly that your environment is set up and ready to go.
 """
-# ENV: full_datasets
-# start_here loads real full-resolution FITS data; SMALL_DATASETS would
-# break the committed data/mask shapes.
 
 import subprocess
 import sys
@@ -498,4 +495,18 @@ The following locations of the workspace are good places to checkout next:
 - `autolens_workspace/guides/results`: How to load and analyze the results of your lens model fits, including tools for large samples.
 - `autolens_workspace/guides`: A complete description of the API and information on lensing calculations and units.
 - `autolens_workspace/interferometer/features`: A description of advanced features for lens modeling, for example pixelized source reconstructions, read this once you're confident with the basics!
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+start_here loads real full-resolution FITS data; SMALL_DATASETS would break
+the committed data/mask shapes.
+
+ENV: full_datasets
 """

--- a/scripts/multi/start_here.py
+++ b/scripts/multi/start_here.py
@@ -59,9 +59,6 @@ The code below sets up your environment if you are using Google Colab, including
 files required to run the notebook. If you are running this script not in Colab (e.g. locally on your own computer),
 running the code will still check correctly that your environment is set up and ready to go.
 """
-# ENV: full_datasets
-# start_here loads real full-resolution FITS data; SMALL_DATASETS would
-# break the committed data/mask shapes.
 
 import subprocess
 import sys
@@ -465,4 +462,18 @@ but maybe you want to try and model your own lens first!
 The following locations of the workspace are good places to checkout next:
 
 - `autolens_workspace/*/multi/features`: A full description of the multi wavelength and multi image fitting.
+"""
+
+"""
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+start_here loads real full-resolution FITS data; SMALL_DATASETS would break
+the committed data/mask shapes.
+
+ENV: full_datasets
 """


### PR DESCRIPTION
## Overview

Follow-up to PyAutoLabs/PyAutoHands#187 per user feedback (PyAutoLabs/PyAutoHands#189; mechanism PR: PyAutoLabs/PyAutoHands#190 — merge that first): the `# ENV:` comment declarations move into the workspace docstring doctrine as `__Env__` sections. User workspaces place them at the BOTTOM with an explicit developer-only note and they are stripped from generated notebooks/markdown; `*_test` repos place them near the top after the module docstring. Each declaration's rationale comment is folded into the section prose.

## Scripts Changed

- `scripts/**` — every script that carried a `# ENV:` line now carries a `__Env__` docstring section instead (see file list). No config files touched.

## Verification

- Resolved-env diff vs HEAD (declarations active on both sides, empty base, smoke + release): **identical for every script** — a pure syntax move.
- All-strict validator (incl. `--strict-declarations`): 0 errors.
- `grep -rn "# ENV:" scripts/`: 0 hits.
- (User workspaces) real notebook generation on sampled scripts: zero `__Env__`/`ENV:` leakage.

## Ship note

Shipped under human-acknowledged Heart YELLOW (workspace-validation backlog + stale parks, pre-existing).

Linked issue: PyAutoLabs/PyAutoHands#189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRQH5HrmMPfpWkmfh3ysJb
