### PR TITLE
refactor: fold __Env__ into the adjacent docstring

### DIFF
--- a/scripts/group/start_here.py
+++ b/scripts/group/start_here.py
@@ -405,9 +405,7 @@ The following locations of the workspace are good places to checkout next:
 - `autolens_workspace/guides/results`: How to load and analyze the results of your lens model fits, including tools for large samples.
 - `autolens_workspace/guides`: A complete description of the API and information on lensing calculations and units.
 - `autolens_workspace/group/features`: A description of advanced features for lens modeling, for example pixelized source reconstructions, read this once you're confident with the basics!
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/advanced/add_a_profile.py
+++ b/scripts/guides/advanced/add_a_profile.py
@@ -668,9 +668,7 @@ Show how to wrap existing profiles with physical units?
 __Light Profiles__
 
 Pretty much the same but need to add text.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/advanced/custom_analysis.py
+++ b/scripts/guides/advanced/custom_analysis.py
@@ -600,10 +600,7 @@ I will extend this guide to include the following in the next few days:
  - Add methods which output model-specific results to hard-disk in the files folder (e.g. as .json files) to aid in 
  the interpretation of results.
  - How to output results to hard-disk in a format that can be loaded into the **PyAutoLens** database.
- 
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/advanced/multi_plane.py
+++ b/scripts/guides/advanced/multi_plane.py
@@ -699,9 +699,7 @@ time, we use a sample of five cluster strong lenses to measure the values of cos
 with those from classical probes. In order to assess the degeneracies and the effectiveness of strong-lensing 
 cosmography in constraining the background geometry of the Universe, we adopt four cosmological scenarios. We find 
 good constraining power on the total matter density of the Universe ($Ω_{\rm m}$) and the equation of state of the dark e… Show more
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/advanced/over_sampling.py
+++ b/scripts/guides/advanced/over_sampling.py
@@ -555,9 +555,7 @@ The numerical verification of all of the above lives in
 brute-force reference calculations.
 
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/advanced/over_sampling_chaining.py
+++ b/scripts/guides/advanced/over_sampling_chaining.py
@@ -292,9 +292,7 @@ print(result_2.info)
 
 """
 Fin.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/advanced/potential_correction.py
+++ b/scripts/guides/advanced/potential_correction.py
@@ -332,9 +332,7 @@ hyper-parameters — with all linear algebra available under numpy or JAX throug
 
 If you use this functionality, please cite Cao et al. 2025
 (https://github.com/caoxiaoyue/potential_correction_paper) alongside PyAutoLens.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/coolest_interop.py
+++ b/scripts/guides/coolest_interop.py
@@ -137,9 +137,7 @@ Light: `Sersic` / `SersicSph`. Mass: `Isothermal` / `IsothermalSph` (SIE), `Powe
 an error naming the profile.
 
 Fin.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/data_structures.py
+++ b/scripts/guides/data_structures.py
@@ -503,9 +503,7 @@ Plotting and `.fits` writers handle the conversion transparently.
 
 """
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/galaxies.py
+++ b/scripts/guides/galaxies.py
@@ -272,9 +272,7 @@ The full deep-dive on the bound-method vs traced-argument trade-off,
 cache-identity footguns, and the `@jax.jit + xp=jnp` pairing rule lives
 in `scripts/guides/lens_calc.py`. The `.array` host-transfer mechanics
 live in `scripts/guides/data_structures.py`.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/lens_calc.py
+++ b/scripts/guides/lens_calc.py
@@ -613,9 +613,7 @@ For further reading:
 - ``guides/data_structures.py`` — the ``Array2D``, ``Grid2D`` and ``VectorYX2D`` data structures.
 
 The `LensCalc` class is also available via `al.LensCalc` — it lives in ``PyAutoGalaxy/autogalaxy/operate/lens_calc.py``.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/modeling/advanced/graphical.py
+++ b/scripts/guides/modeling/advanced/graphical.py
@@ -271,9 +271,7 @@ inference.
 This example used a simple shared parameter (the Hubble constant) across multiple lenses. The same framework can be
 extended to far more complex models, with many shared or linked parameters, enabling powerful hierarchical and
 population-level inference for large lens samples.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/modeling/advanced/hierarchical.py
+++ b/scripts/guides/modeling/advanced/hierarchical.py
@@ -315,9 +315,7 @@ us to fit graphs with hundreds of components and tens of thousands of parameters
 optimizations.
 
 This makes hierarchical graphical modeling **scalable to the largest datasets and most complex models.**
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/modeling/chaining.py
+++ b/scripts/guides/modeling/chaining.py
@@ -383,9 +383,7 @@ If the prior config file had specified that we use an relative value of 0.8, the
 mean=4.0 and sigma = 4.0 * 0.8 = 3.2.
 
 And with that, we're done. Chaining priors is a bit of an art form, but one that works really well. 
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/modeling/cookbook.py
+++ b/scripts/guides/modeling/cookbook.py
@@ -431,9 +431,7 @@ https://pyautofit.readthedocs.io/en/latest/cookbooks/multi_level_model.html
 __Wrap Up__
 
 This cookbook shows how to compose simple lens models using the `af.Model()` and `af.Collection()` objects.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/modeling/customize.py
+++ b/scripts/guides/modeling/customize.py
@@ -270,9 +270,7 @@ analysis = al.AnalysisImaging(
 
 """
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/modeling/searches.py
+++ b/scripts/guides/modeling/searches.py
@@ -332,9 +332,7 @@ The **PyAutoFit** search cookbook documents all searches that are available, inc
 and provides the code you can easily copy and paste to use these methods.
 
 https://pyautofit.readthedocs.io/en/latest/cookbooks/search.html
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/modeling/slam_start_here.py
+++ b/scripts/guides/modeling/slam_start_here.py
@@ -637,9 +637,7 @@ mass_result = mass_total(
 
 """
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/plot/advanced/plotters_double_einstein_ring.py
+++ b/scripts/guides/plot/advanced/plotters_double_einstein_ring.py
@@ -212,9 +212,7 @@ aplt.plot_array(
 
 """
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/plot/advanced/plotters_pixelization.py
+++ b/scripts/guides/plot/advanced/plotters_pixelization.py
@@ -263,9 +263,7 @@ aplt.plot_array(
 
 """
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/plot/examples/mat_plot.py
+++ b/scripts/guides/plot/examples/mat_plot.py
@@ -153,9 +153,7 @@ This allows project-wide defaults to be set without changing code.
 
 """
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/plot/examples/plotters.py
+++ b/scripts/guides/plot/examples/plotters.py
@@ -391,9 +391,7 @@ aplt.subplot_fit_point(fit=fit)
 
 """
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/plot/examples/searches.py
+++ b/scripts/guides/plot/examples/searches.py
@@ -854,9 +854,7 @@ plt.close()
 Note that the models do not need to be the same to make the plots above.
 
 GetDist will clever use the `names` of the parameters to combine the parameters into customizeable PDF plots.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/plot/examples/visuals.py
+++ b/scripts/guides/plot/examples/visuals.py
@@ -264,9 +264,7 @@ aplt.plot_array(
 
 """
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/plot/start_here.py
+++ b/scripts/guides/plot/start_here.py
@@ -215,9 +215,7 @@ aplt.subplot_fit_imaging(fit=fit)
 """
 The search plotting functions (`aplt.corner_anesthetic`, `aplt.corner_cornerpy`, etc.) provide
 visualization of non-linear search results -- see `scripts/guides/plot/examples/searches.py`.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/point_source_pairing.py
+++ b/scripts/guides/point_source_pairing.py
@@ -181,9 +181,7 @@ print(f"  chi_squared = {float(fit.chi_squared):.4f}")
 """
 Finished. For the production-scale picture — real solver, multi-plane cluster tracer, timings —
 see ``scripts/cluster/likelihood_function.py`` and the profiling breakdowns referenced above.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/profiles/light.py
+++ b/scripts/guides/profiles/light.py
@@ -645,9 +645,7 @@ subpackages handle the family-specific workflows referenced throughout this guid
 For the mass-profile counterpart of this guide, see `scripts/guides/profiles/mass.py`
 (when available).  For a full walk-through of how light and mass profiles are combined in
 the `Tracer` to produce lensed images, see `scripts/guides/tracer.py`.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/profiles/light_and_mass_profiles.py
+++ b/scripts/guides/profiles/light_and_mass_profiles.py
@@ -750,9 +750,7 @@ For the next step into actual lens modelling, see `scripts/imaging/modeling/star
 (strong-lens fit end-to-end) and the topic-specific feature packages under
 `scripts/imaging/features/`.  The SLaM pipeline guide (`scripts/guides/modeling/slam_start_here.py`)
 shows the production decomposed-lens workflow built on these profiles.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/profiles/mass.py
+++ b/scripts/guides/profiles/mass.py
@@ -625,9 +625,7 @@ profiles in an actual lens fit, the next step is `scripts/imaging/modeling/start
 which sets up an `AnalysisImaging` and runs a non-linear search end-to-end on a strong-lens
 dataset.  For a deeper walk-through of how mass profiles combine with light profiles in the
 `Tracer` to produce lensed images, see `scripts/guides/tracer.py`.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -202,9 +202,7 @@ for fit_list_gen in fit_gen:  # 1 Dataset so just one fit
 
 """
 Finished.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/aggregator/galaxies_fits.py
+++ b/scripts/guides/results/aggregator/galaxies_fits.py
@@ -253,9 +253,7 @@ __Wrap Up__
 
 We have learnt how to extract individual planes, galaxies, light and mass profiles from the tracer that results from
 a model-fit and use these objects to compute specific quantities of each component.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/aggregator/interferometer.py
+++ b/scripts/guides/results/aggregator/interferometer.py
@@ -32,9 +32,7 @@ harm either.
 One caveat may be magnifications. It could be that as you make the shape of the interpolation grid bigger, the
 magnification changes. I'm not sure on this but would advise you experiment to see if the magnifications 
 seem "stable" (assuming you are estimate a magnification at some point).
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/aggregator/models.py
+++ b/scripts/guides/results/aggregator/models.py
@@ -233,9 +233,7 @@ for tracer_gen in tracer_list_gen:
 
 """
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -143,9 +143,7 @@ print(
 
 """
 Finished.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -605,9 +605,7 @@ print(samples.parameter_lists[0])
 
 """
 Fin.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -556,9 +556,7 @@ print(samples.parameter_lists[0])
 
 """
 Finished.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/database/start_here.py
+++ b/scripts/guides/results/database/start_here.py
@@ -348,9 +348,7 @@ This example illustrates how to use the database.
 
 The API above can be combined with the `results/aggregator` scripts in order to use the database to load results and
 perform analysis on them.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/latent_variables.py
+++ b/scripts/guides/results/latent_variables.py
@@ -289,9 +289,7 @@ Pipeline-specific latents that need non-standard kwargs (PSF-relative aperture f
 photometric quantities, multi-band colour terms) belong in your pipeline's local Analysis subclass. The Euclid
 pipeline (``euclid_strong_lens_modeling_pipeline/util.py``) demonstrates this — its FWHM aperture-flux latents
 stay pipeline-local and the rest inherit from the library.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -620,9 +620,7 @@ The example script `autolens_workspace/*/features/pixelization.py` describes usi
 
 Therefore if your results contain a pixelization, checkout the example script above for a detailed description
 of how to use their results.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/workflow/fits_make.py
+++ b/scripts/guides/results/workflow/fits_make.py
@@ -291,9 +291,7 @@ which they can then extract and make together.
 __Path Navigation__
 
 Example combinig `fit.fits` from `source_lp[1]` and `mass_total[0]`.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/results/workflow/png_make.py
+++ b/scripts/guides/results/workflow/png_make.py
@@ -257,9 +257,7 @@ which they can then extract and make together.
 __Path Navigation__
 
 Example combinng `subplot_fit.png` from `source_lp[1]` and `mass_total[0]`.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/tracer.py
+++ b/scripts/guides/tracer.py
@@ -595,9 +595,7 @@ covers the `.array` host-transfer story.
 
 """
 Fin.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/guides/units/flux.py
+++ b/scripts/guides/units/flux.py
@@ -296,9 +296,7 @@ populated with NaN and a single warning per process notes that the conversion wa
 unaffected.
 
 Finish.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/imaging/start_here.py
+++ b/scripts/imaging/start_here.py
@@ -584,9 +584,7 @@ The following locations of the workspace are good places to checkout next:
 - `autolens_workspace/guides/results`: How to load and analyze the results of your lens model fits, including tools for large samples.
 - `autolens_workspace/guides`: A complete description of the API and information on lensing calculations and units.
 - `autolens_workspace/imaging/features`: A description of advanced features for lens modeling, for example pixelized source reconstructions, read this once you're confident with the basics!
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -495,9 +495,7 @@ The following locations of the workspace are good places to checkout next:
 - `autolens_workspace/guides/results`: How to load and analyze the results of your lens model fits, including tools for large samples.
 - `autolens_workspace/guides`: A complete description of the API and information on lensing calculations and units.
 - `autolens_workspace/interferometer/features`: A description of advanced features for lens modeling, for example pixelized source reconstructions, read this once you're confident with the basics!
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.

--- a/scripts/multi/start_here.py
+++ b/scripts/multi/start_here.py
@@ -462,9 +462,7 @@ but maybe you want to try and model your own lens first!
 The following locations of the workspace are good places to checkout next:
 
 - `autolens_workspace/*/multi/features`: A full description of the multi wavelength and multi image fitting.
-"""
 
-"""
 __Env__ (Developer Only)
 
 Not user documentation: this section configures the automated test harness.


### PR DESCRIPTION
## Overview

Refinement 2 of PyAutoLabs/PyAutoHands#189 (parser/strip support: PyAutoLabs/PyAutoHands#191 — merge that first): the standalone `__Env__` docstring violated the workspace doctrine — multiple `__Section__` headers belong in one docstring, not a `"""` close-then-reopen pair. `__Env__` now sits as the **last section inside the adjacent docstring**: the final docstring in user-facing scripts, the module docstring in `*_test` scripts. A standalone block remains only where a script has no adjacent docstring.

## Scripts Changed

- `scripts/**` — every script carrying a standalone `__Env__` docstring has it folded into the adjacent docstring (see file list). No config files touched.

## Verification

- Resolved-env diff vs HEAD (empty base, both profiles): **identical for every script** — pure syntax move.
- (User workspaces) real notebook generation on sampled scripts: zero `__Env__`/`ENV:` leakage; the host docstring's prose renders unchanged.
- All-strict validator: 0 errors.

## Ship note

Same human-acknowledged Heart YELLOW lineage as the #189 ship (workspace-validation backlog + stale parks, pre-existing).

Linked issue: PyAutoLabs/PyAutoHands#189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRQH5HrmMPfpWkmfh3ysJb
