### PR TITLE
docs: link Colab introduction to workspace start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Installation Guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html) |
 [readthedocs](https://pyautolens.readthedocs.io/en/latest/index.html) |
-[Introduction on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb) |
+[Introduction on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.23.1/start_here.ipynb) |
 [Browse Examples With Images](markdown/README.md) |
 [HowToLens](https://github.com/PyAutoLabs/HowToLens)
 
@@ -23,7 +23,7 @@ The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assista
 The following human-readable documentation and examples are also useful for new starters:
 
 - [Installation guide](https://pyautolens.readthedocs.io/): set up **PyAutoLens** on your personal computer.
-- [PyAutoLens on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb): try **PyAutoLens** in a web browser without installing it.
+- [PyAutoLens on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.23.1/start_here.ipynb): try **PyAutoLens** in a web browser without installing it.
 
 ## New Users
 
@@ -32,7 +32,7 @@ overview of **PyAutoLens**'s core features and API.
 
 This can be done via a web browser by going to the following Google Colab link:
 
-https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb
+https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.23.1/start_here.ipynb
 
 Then checkout the [new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) to navigate the
 workspace for your science case.


### PR DESCRIPTION
## Summary
Route generic PyAutoLens Colab introduction links to the workspace-root `start_here.ipynb` instead of the imaging-specific notebook. Explicit links for imaging tutorials remain unchanged.

## Scripts Changed
- None — README-only documentation link correction.

## Upstream PR
https://github.com/PyAutoLabs/PyAutoLens/pull/650

## Test Plan
- [ ] Targeted `autolens_workspace` smoke tests pass
- [x] Root `start_here.py` and `start_here.ipynb` contain `setup_colab.for_autolens(...)`
- [x] Generic introduction scan has no imaging-notebook targets
- [x] `git diff --check`

Generated by the PyAutoLabs agent workflow.