### PR TITLE
fix: release exempts imaging potential_correction from SMALL_DATASETS

### DIFF
--- a/config/build/profile_release.yaml
+++ b/config/build/profile_release.yaml
@@ -49,11 +49,15 @@ overrides:
     set: { PYAUTO_SMALL_DATASETS: "0" }
   # Potential correction builds a dpsi mesh by subsampling the image grid, so the
   # 15x15 small-datasets cap starves it: al.pc.PairRegularDpsiMesh(dpsi_factor=2)
-  # raises "The dpsi grid is too sparse" from mesh.py's get_itp_box_ctr. Note the
-  # "interferometer/start_here" pattern above does NOT cover these — their paths are
-  # interferometer/features/potential_correction/..., which that substring misses.
-  # Uncapped they are cheap: start_here.py runs in ~58s against the 1800s cap.
+  # raises "The dpsi grid is too sparse" from mesh.py's get_itp_box_ctr. Both the
+  # interferometer and imaging siblings under features/potential_correction/ need
+  # the cap lifted; the "*/start_here" patterns above do NOT cover them — their
+  # paths are {interferometer,imaging}/features/potential_correction/..., which
+  # that substring misses. Uncapped they are cheap: start_here.py runs in ~58s
+  # against the 1800s cap.
   - pattern: "interferometer/features/potential_correction/"
+    set: { PYAUTO_SMALL_DATASETS: "0" }
+  - pattern: "imaging/features/potential_correction/"
     set: { PYAUTO_SMALL_DATASETS: "0" }
   # Non-simulator scripts that load committed FITS data need full-size
   # datasets to avoid shape mismatch with pre-existing 100x100 data.


### PR DESCRIPTION
## Overview
#332 (found during autolens_workspace_test#213): the release profile exempted `interferometer/features/potential_correction/` from the small-datasets cap but not the imaging sibling, which therefore ran its `dpsi_factor=2` mesh starved (the July #315 failure shape). One-line mirror of the sibling override; declaration alternative rejected (would also lift the smoke cap).

## Verification
Smoke resolution byte-identical for all 273 scripts; release changes exactly `imaging/features/potential_correction/likelihood_function.py` (the only file the pattern matches, content-confirmed dpsi/mesh); validator all-strict 0.

## Ship note
Human-acknowledged Heart YELLOW (workspace-validation backlog + 33 stale parks, pre-existing).

Linked issue: #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRQH5HrmMPfpWkmfh3ysJb