### PR TITLE
refactor: remove standalone matplotlib-inline comments

### DIFF
--- a/dataset/imaging/slacs1430+4105/data.py
+++ b/dataset/imaging/slacs1430+4105/data.py
@@ -9,7 +9,6 @@ In this script, we fit `Imaging` with a strong lens model where:
  - The source galaxy's light is a parametric `Sersic`.
 """
 
-# %matplotlib inline
 import numpy as np
 import autofit as af
 import autolens as al

--- a/start_here.ipynb
+++ b/start_here.ipynb
@@ -69,8 +69,6 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "# %matplotlib inline\n",
-        "\n",
         "from pathlib import Path\n",
         "import matplotlib.pyplot as plt\n",
         "\n",

--- a/start_here.py
+++ b/start_here.py
@@ -48,8 +48,6 @@ Lets first import autolens, its plotting module and the other libraries we'll ne
 
 You'll see these imports in the majority of workspace examples.
 """
-# %matplotlib inline
-
 from pathlib import Path
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
## Summary
Remove three inert standalone `# %matplotlib inline` comments from the top-level AutoLens introduction, its paired notebook, and the SLACS dataset helper. The four old-bootstrap potential-correction examples remain deliberately out of scope.

## Scripts Changed
- `start_here.py` — removed the obsolete standalone notebook-magic comment.
- `start_here.ipynb` — regenerated from the authored top-level script.
- `dataset/imaging/slacs1430+4105/data.py` — removed the unpaired standalone comment.

## Test Plan
- [x] Generated notebook parses as valid JSON.
- [x] `git diff --check` passes.
- [ ] AutoLens workspace smoke runner passes.

Tracks PyAutoLabs/autogalaxy_workspace#160.

Generated by the PyAutoLabs agent workflow.