### PR TITLE
docs: post-merge residual fixes — folder-index READMEs + prep.py LF line endings

### DIFF
--- a/dataset/cluster/a2744/prep.py
+++ b/dataset/cluster/a2744/prep.py
@@ -67,7 +67,7 @@ for k in gold:
 selected = [chosen[f] for f in sorted(chosen, key=float)]
 
 with open(OUT / "point_datasets.csv", "w", newline="") as f:
-    writer = csv.writer(f)
+    writer = csv.writer(f, lineterminator="\n")
     writer.writerow(["name", "y", "x", "positions_noise", "redshift"])
     for i, s in enumerate(selected):
         for image_id, ra, dec, z, qf in sorted(gold[s]):
@@ -92,7 +92,7 @@ bcg_1, bcg_2 = core[0], core[1]
 mag_ref = bcg_1[3]
 
 with open(OUT / "scaling_galaxies.csv", "w", newline="") as f:
-    writer = csv.writer(f)
+    writer = csv.writer(f, lineterminator="\n")
     writer.writerow(["y", "x", "luminosity"])
     for member_id, y, x, mag, radius in sorted(members, key=lambda m: m[3]):
         if member_id in (bcg_1[0], bcg_2[0]) or radius > MEMBER_RADIUS_MAX:
@@ -102,7 +102,7 @@ with open(OUT / "scaling_galaxies.csv", "w", newline="") as f:
 # --- Named-galaxy model CSVs ---
 
 with open(OUT / "mass.csv", "w", newline="") as f:
-    writer = csv.writer(f)
+    writer = csv.writer(f, lineterminator="\n")
     writer.writerow(
         ["galaxy", "attr_name", "profile_class", "y", "x", "sigma", "r_core", "r_cut",
          "mass_at_200", "redshift_object", "redshift_source", "H0", "Om0", "redshift"]
@@ -125,7 +125,7 @@ with open(OUT / "mass.csv", "w", newline="") as f:
     )
 
 with open(OUT / "point.csv", "w", newline="") as f:
-    writer = csv.writer(f)
+    writer = csv.writer(f, lineterminator="\n")
     writer.writerow(["galaxy", "attr_name", "profile_class", "y", "x", "redshift"])
     for i, s in enumerate(selected):
         positions = np.array([project(ra, dec) for _, ra, dec, _, _ in gold[s]])

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -12,6 +12,7 @@ you should go into next if you are unsure.
 - `imaging`: Examples for galaxy scale strong lenses observed with CCD imaging (e.g. Hubble, Euclid).
 - `interferometer`: Examples for galaxy scale strong lenses observed with an interferometer (e.g. ALMA, JVLA).
 - `point_source`: Examples for strong lens point source datasets.
+- `multi_galaxy`: Examples for multi-galaxy strong lenses (2+ co-dominant lens galaxies, no host halo).
 - `group`: Examples for group scale strong lenses.
 - `cluster`: Examples for cluster scale strong lenses.
 - `multi`: Examples for multiple datasets simultaneously (E.g. multi-wavelength imaging, imaging and interferometry).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,7 @@ you should go into next if you are unsure.
 - `imaging`: Examples for galaxy scale strong lenses observed with CCD imaging (e.g. Hubble, Euclid).
 - `interferometer`: Examples for galaxy scale strong lenses observed with an interferometer (e.g. ALMA, JVLA).
 - `point_source`: Examples for strong lens point source datasets.
+- `multi_galaxy`: Examples for multi-galaxy strong lenses (2+ co-dominant lens galaxies, no host halo).
 - `group`: Examples for group scale strong lenses.
 - `cluster`: Examples for cluster scale strong lenses.
 - `multi`: Examples for multiple datasets simultaneously (E.g. multi-wavelength imaging, imaging and interferometry).


### PR DESCRIPTION
Two SHOULD-FIX findings from the post-merge Opus residual sweep of the regime reorganization (#346):

- `scripts/README.md` and `notebooks/README.md` folder indexes now list the `multi_galaxy` package (the root, group and cluster READMEs were already updated in #346 — these two were the only misses).
- `dataset/cluster/a2744/prep.py` csv writers now emit LF (`lineterminator="\n"`) so regeneration reproduces the committed LF `mass.csv` byte-for-byte instead of rewriting it as CRLF (the sweep verified all lens-row values already reproduce exactly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Eacj9naBWSKrevsqnVJWR

---
_Generated by [Claude Code](https://claude.ai/code/session_012Eacj9naBWSKrevsqnVJWR)_