### PR TITLE
fix(interferometer): skip the Delaunay example when nufftax is unavailable

### DIFF
--- a/notebooks/interferometer/features/pixelization/delaunay.ipynb
+++ b/notebooks/interferometer/features/pixelization/delaunay.ipynb
@@ -144,8 +144,52 @@
     "\n",
     "import autofit as af\n",
     "import autolens as al\n",
-    "import autolens.plot as aplt\n",
+    "import autolens.plot as aplt"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__NUFFT Backend Check__\n",
     "\n",
+    "Interferometer analysis uses the default `TransformerNUFFT`, backed by the\n",
+    "`nufftax` NUFFT library. It ships with the `[optional]` extras and requires\n",
+    "Python >= 3.12. When it is not installed (e.g. the NumPy-only CI matrix), skip\n",
+    "this example gracefully rather than erroring on the data-simulation step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import importlib.util\n",
+    "import sys\n",
+    "\n",
+    "if importlib.util.find_spec(\"nufftax\") is None:\n",
+    "    print(\n",
+    "        \"Skipping interferometer example: the `nufftax` NUFFT backend is not \"\n",
+    "        \"installed (install with `pip install autolens[optional]`; requires \"\n",
+    "        \"Python >= 3.12).\"\n",
+    "    )\n",
+    "    sys.exit(0)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Mask (Real Space)__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
     "mask_radius = 3.5\n",
     "\n",
     "real_space_mask = al.Mask2D.circular(\n",

--- a/scripts/interferometer/features/pixelization/delaunay.py
+++ b/scripts/interferometer/features/pixelization/delaunay.py
@@ -99,6 +99,28 @@ import autofit as af
 import autolens as al
 import autolens.plot as aplt
 
+"""
+__NUFFT Backend Check__
+
+Interferometer analysis uses the default `TransformerNUFFT`, backed by the
+`nufftax` NUFFT library. It ships with the `[optional]` extras and requires
+Python >= 3.12. When it is not installed (e.g. the NumPy-only CI matrix), skip
+this example gracefully rather than erroring on the data-simulation step.
+"""
+import importlib.util
+import sys
+
+if importlib.util.find_spec("nufftax") is None:
+    print(
+        "Skipping interferometer example: the `nufftax` NUFFT backend is not "
+        "installed (install with `pip install autolens[optional]`; requires "
+        "Python >= 3.12)."
+    )
+    sys.exit(0)
+
+"""
+__Mask (Real Space)__
+"""
 mask_radius = 3.5
 
 real_space_mask = al.Mask2D.circular(


### PR DESCRIPTION
## The failure

`PyAutoHands` weekly `python_matrix` fails on **Python 3.11 only**, on one script:

```
FAIL: interferometer/features/pixelization/delaunay.py
```

Its auto-simulation step shells out to `scripts/interferometer/simulator.py`, which builds the default `TransformerNUFFT` and dies with `ModuleNotFoundError: nufftax`. 3.12 and 3.13 pass.

## Why nufftax genuinely isn't available there

Not a CI misconfiguration — there is currently **no usable nufftax release on 3.11**:

| Version | Installs on 3.11? | Works with our JAX 0.10 stack? |
|---|---|---|
| 0.4.0 (what `autoarray[optional]` pins) | ✗ `requires_python >= 3.12` | ✓ |
| 0.6.0 | ✓ | ✗ `jax.interpreters.batching.not_mapped` removed in JAX 0.10 |
| 0.6.1 | ✓ | ✗ rank-4 input under vmap → `ValueError: too many values to unpack (expected 3)` |

Bumping the pin was tried and reverted; details in PyAutoArray#409.

## The change

Adds the existing optional-dependency skip guard. It is **byte-identical** (modulo the package name) to the one already in `interferometer/modeling.py` and `autogalaxy_workspace/interferometer/start_here.py` — verified by `diff`, not by eye. That guard is why the autogalaxy 3.11 leg passes today:

```
Skipping interferometer example: the `nufftax` NUFFT backend is not installed
(install with `pip install autogalaxy[optional]`; requires Python >= 3.12).
PASS: interferometer/start_here.py
```

## Scope: why only this one script

The guard is a **CI affordance**, not user-facing machinery — only scripts in `smoke_tests.txt` need it. Across all four workspaces exactly three smoke-listed scripts live-use `TransformerNUFFT` (checked by AST, so embedded prose mentions don't count), and with this change all three are guarded:

```
GUARDED  autolens_workspace/interferometer/modeling.py
GUARDED  autolens_workspace/interferometer/features/pixelization/delaunay.py   <- this PR
GUARDED  autogalaxy_workspace/interferometer/start_here.py
```

The ~30 other interferometer scripts are **deliberately left unguarded** — they are not in CI, and a user running them should get a real error, not a silent skip. PyAutoArray#409 makes that error Python-version aware so a 3.11 user is told to upgrade rather than to `pip install nufftax` (which would install a broken 0.6.x and fail mid-fit).

## Verification

- skip path exits **0** — a PASS for the smoke runner; notebooks are covered by `build_util.is_clean_skip_exit`, which `autolens_workspace/.github/scripts/run_smoke.py` already imports
- with nufftax present the script still runs unchanged: **exit 0**, guard not triggered
- `scripts/check_sizes.sh` → `OK: all scripts within size tolerance`
- notebook regenerated with PyAutoHands `generate.py`; guard lands as its own code cell behind the markdown block, and no other notebook or the catalogue changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EZTtyLUAyKWuATyk4mkcm