### PR TITLE
fix: track the HPC batch output/ log dirs so SLURM jobs can start

### DIFF
--- a/scripts/guides/hpc/batch_cpu/output/.gitignore
+++ b/scripts/guides/hpc/batch_cpu/output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/guides/hpc/batch_gpu/output/.gitignore
+++ b/scripts/guides/hpc/batch_gpu/output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary

Follow-up to #361, fixing a defect that PR introduced.

The root `.gitignore` has `output/`, which matches **any** `output/` directory at
any depth. So when #361 added the SLURM log-directory stubs,
`scripts/guides/hpc/batch_{cpu,gpu}/output/.gitignore` were silently refused by
`git add -A`, while the sibling `error/` stubs went in fine. Git does not warn
when an ignored path is skipped by `add -A`, so this passed every check —
smoke, navigator and banner lint all care about `scripts/` references, not about
whether an empty log directory is tracked.

The consequence is real: on a fresh clone the stdout log directory does not
exist, and `sbatch` rejects a job whose `-o` directory is missing. A user
following the guide would hit a submission failure on their first
`sbatch scripts/guides/hpc/batch_cpu/submit`.

`autogalaxy_workspace` was unaffected because it already tracks both files —
force-added when its batch directories were first created — which is exactly why
the two repos diverged here despite the identical intent.

Force-added to match.

## Scripts Changed

- `scripts/guides/hpc/batch_cpu/output/.gitignore` — force-added; ignores SLURM stdout logs while keeping the directory in the tree
- `scripts/guides/hpc/batch_gpu/output/.gitignore` — likewise

## Test Plan

- [x] `git ls-tree -r HEAD scripts/guides/hpc/` now lists all four `output/` + `error/` stubs, matching autogalaxy_workspace
- [ ] CI green

Related: #360, #361

Generated by the PyAutoLabs agent workflow.