### PR TITLE
fix: point auto-simulate guards at the simulator that writes the loaded dataset

### DIFF
--- a/notebooks/imaging/features/multi_gaussian_expansion/likelihood_function.ipynb
+++ b/notebooks/imaging/features/multi_gaussian_expansion/likelihood_function.ipynb
@@ -128,7 +128,7 @@
    "metadata": {},
    "source": [
     "dataset_name = \"lens_light_asymmetric\"\n",
-    "dataset_path = Path(\"dataset\", \"imaging\", \"simple\")"
+    "dataset_path = Path(\"dataset\", \"imaging\", dataset_name)"
    ],
    "outputs": [],
    "execution_count": null

--- a/notebooks/imaging/features/pixelization/likelihood_function.ipynb
+++ b/notebooks/imaging/features/pixelization/likelihood_function.ipynb
@@ -163,7 +163,7 @@
     "    import sys\n",
     "\n",
     "    subprocess.run(\n",
-    "        [sys.executable, \"scripts/imaging/features/no_lens_light/simulator.py\"],\n",
+    "        [sys.executable, \"scripts/imaging/simulator.py\"],\n",
     "        check=True,\n",
     "    )\n",
     "\n",

--- a/notebooks/multi/features/slam/simultaneous.ipynb
+++ b/notebooks/multi/features/slam/simultaneous.ipynb
@@ -141,8 +141,7 @@
     "pixel_scale_list = [0.12, 0.08]\n",
     "\n",
     "dataset_name = \"lens_sersic\"\n",
-    "dataset_main_path = Path(\"dataset\", \"multi\", \"imaging\", dataset_name)\n",
-    "dataset_path = Path(dataset_main_path, dataset_name)"
+    "dataset_main_path = Path(\"dataset\", \"multi\", \"imaging\", dataset_name)"
    ],
    "outputs": [],
    "execution_count": null
@@ -161,7 +160,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "if al.util.dataset.should_simulate(str(dataset_path)):\n",
+    "if al.util.dataset.should_simulate(str(dataset_main_path)):\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",

--- a/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
@@ -69,7 +69,7 @@ This example fits a simulated galaxy where galaxy has an asymmetric light distri
 fitted with `Sersic` profile and therefore requires a multi-Gaussian expansion to fit accurately.
 """
 dataset_name = "lens_light_asymmetric"
-dataset_path = Path("dataset", "imaging", "simple")
+dataset_path = Path("dataset", "imaging", dataset_name)
 
 """
 __Dataset Auto-Simulation__

--- a/scripts/imaging/features/pixelization/likelihood_function.py
+++ b/scripts/imaging/features/pixelization/likelihood_function.py
@@ -93,7 +93,7 @@ if al.util.dataset.should_simulate(str(dataset_path)):
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/imaging/features/no_lens_light/simulator.py"],
+        [sys.executable, "scripts/imaging/simulator.py"],
         check=True,
     )
 

--- a/scripts/multi/features/slam/simultaneous.py
+++ b/scripts/multi/features/slam/simultaneous.py
@@ -83,7 +83,6 @@ pixel_scale_list = [0.12, 0.08]
 
 dataset_name = "lens_sersic"
 dataset_main_path = Path("dataset", "multi", "imaging", dataset_name)
-dataset_path = Path(dataset_main_path, dataset_name)
 
 """
 __Dataset Auto-Simulation__
@@ -91,7 +90,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if al.util.dataset.should_simulate(str(dataset_path)):
+if al.util.dataset.should_simulate(str(dataset_main_path)):
     import subprocess
     import sys
 


### PR DESCRIPTION
Fixes the auto-simulate guards that run a simulator writing a **different dataset** than the script then loads, so the guard fires, a simulator runs, and `from_fits` still raises `FileNotFoundError`.

Closes #359.

## Root cause

The open question on #359 was whether the guard targets were always wrong or whether `should_simulate` regressed. **It is the former.** `PyAutoArray/autoarray/util/dataset_util.py:54` is an exact drop-in for `not path.exists()` when `PYAUTO_SMALL_DATASETS` is unset — there is no wider `should_simulate` bug.

One hazard worth knowing: under `PYAUTO_SMALL_DATASETS=1` (set by both `profile_smoke.yaml` and `profile_release.yaml`) the helper `rmtree`s the directory *before* testing it. So a mis-targeted guard does not merely fail to produce the right dataset — it destroys a correct one that was satisfying the load. That is the amplifier that turned an old latent mismatch into red CI.

## Scripts Changed

- `scripts/imaging/features/pixelization/likelihood_function.py` — guard ran the `no_lens_light` simulator (writes `imaging/simple__no_lens_light`) while the script loads `imaging/simple`. The script builds a lens galaxy with a `bulge`, so `simple` is the right data; repointed at `scripts/imaging/simulator.py`. Repointing the *load* instead would have fed the script the wrong dataset.
- `scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py` — **the guard was already correct.** The load path hardcoded `"simple"` and ignored `dataset_name = "lens_light_asymmetric"` set on the line above. The script's whole premise is asymmetric light a Sersic cannot fit, so the path is the bug.
- `scripts/multi/features/slam/simultaneous.py` — guard tested `Path(dataset_main_path, dataset_name)`, a doubled `multi/imaging/lens_sersic/lens_sersic` that can never exist, while the loads use `dataset_main_path`. Symptom was not a crash but **re-simulating on every run, forever**. Guard now tests `dataset_main_path`.

Notebooks regenerated via PyAutoHands.

## Verification

The smoke gate **cannot** verify this: none of these scripts appear in `smoke_tests.txt` or `smoke_notebooks.txt`, which is exactly why the migration shipped green. They are deliberately not being bulk-added — that list is a curated subset.

Verified by direct runs from the repo root under `PYAUTO_TEST_MODE=2 PYAUTO_SMALL_DATASETS=1` (the second flag is what exercises the destructive `rmtree` branch, so it is the honest setting):

```
[autolens_workspace] scripts/imaging/features/pixelization/likelihood_function.py          PASS
[autolens_workspace] scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py  PASS
[autolens_workspace] scripts/multi/features/slam/simultaneous.py                          PASS
```

For `simultaneous.py` a single pass proves nothing, so the always-fires symptom was checked separately — after one run the guard path exists and `should_simulate` returns `False`, whereas the old doubled path never existed:

```
guard path exists : True
should_simulate   : False
old (doubled) guard path exists: FALSE   <- would have re-simulated forever
```

A static resolver comparing every guard's `dataset_path` against the invoked simulator's written path now reports zero mismatches across both workspaces.

## Not in scope

PyAutoHands#204 — nbconvert runs kernels in the notebook's own directory, so these guards still fail from **notebooks** regardless of this fix. The `run_notebooks` shards stay red until that lands. This PR makes the scripts correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
