### PR TITLE
Raise deployment runtime to python-3.12.1 (Phase 5B)

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.11
+python-3.12.1


### PR DESCRIPTION
Phase 5B of the Python 3.12 ecosystem-floor migration — part of the six-repository batch tracked at PyAutoLabs/autofit_workspace#125 (parent: PyAutoLabs/PyAutoNerves#142).

One-line change: root `runtime.txt` deployment selector → `python-3.12.1` (terminating newline preserved). The live releases (`2026.7.29.2`) already declare `Requires-Python >=3.12`.

Validation (per the task prompt, intentionally narrow for a deployment-selector line): exact-value census across all six repos + `git diff --check`. No smoke/test sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)