### PR TITLE
fix(multi_galaxy): count source pixels from the mapper; add auto-sim header to 5 slam.py

### DIFF
--- a/notebooks/multi_galaxy/features/extra_galaxies/slam.ipynb
+++ b/notebooks/multi_galaxy/features/extra_galaxies/slam.ipynb
@@ -634,8 +634,25 @@
    "metadata": {},
    "source": [
     "dataset_name = \"extra_galaxies\"\n",
-    "dataset_path = Path(\"dataset\") / \"multi_galaxy\" / dataset_name\n",
+    "dataset_path = Path(\"dataset\") / \"multi_galaxy\" / dataset_name"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Dataset Auto-Simulation__\n",
     "\n",
+    "If the dataset does not already exist on your system, it will be created by running the corresponding\n",
+    "simulator script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
     "if al.util.dataset.should_simulate(str(dataset_path)):\n",
     "    import subprocess\n",
     "    import sys\n",

--- a/notebooks/multi_galaxy/features/linear_light_profiles/slam.ipynb
+++ b/notebooks/multi_galaxy/features/linear_light_profiles/slam.ipynb
@@ -563,8 +563,25 @@
    "metadata": {},
    "source": [
     "dataset_name = \"simple\"\n",
-    "dataset_path = Path(\"dataset\") / \"multi_galaxy\" / dataset_name\n",
+    "dataset_path = Path(\"dataset\") / \"multi_galaxy\" / dataset_name"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Dataset Auto-Simulation__\n",
     "\n",
+    "If the dataset does not already exist on your system, it will be created by running the corresponding\n",
+    "simulator script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
     "if al.util.dataset.should_simulate(str(dataset_path)):\n",
     "    import subprocess\n",
     "    import sys\n",

--- a/notebooks/multi_galaxy/features/multi_gaussian_expansion/slam.ipynb
+++ b/notebooks/multi_galaxy/features/multi_gaussian_expansion/slam.ipynb
@@ -549,8 +549,25 @@
    "metadata": {},
    "source": [
     "dataset_name = \"mge\"\n",
-    "dataset_path = Path(\"dataset\") / \"multi_galaxy\" / dataset_name\n",
+    "dataset_path = Path(\"dataset\") / \"multi_galaxy\" / dataset_name"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Dataset Auto-Simulation__\n",
     "\n",
+    "If the dataset does not already exist on your system, it will be created by running the corresponding\n",
+    "simulator script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
     "if al.util.dataset.should_simulate(str(dataset_path)):\n",
     "    import subprocess\n",
     "    import sys\n",

--- a/notebooks/multi_galaxy/features/no_lens_light/slam.ipynb
+++ b/notebooks/multi_galaxy/features/no_lens_light/slam.ipynb
@@ -482,8 +482,25 @@
    "metadata": {},
    "source": [
     "dataset_name = \"simple__no_lens_light\"\n",
-    "dataset_path = Path(\"dataset\") / \"multi_galaxy\" / dataset_name\n",
+    "dataset_path = Path(\"dataset\") / \"multi_galaxy\" / dataset_name"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Dataset Auto-Simulation__\n",
     "\n",
+    "If the dataset does not already exist on your system, it will be created by running the corresponding\n",
+    "simulator script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
     "if al.util.dataset.should_simulate(str(dataset_path)):\n",
     "    import subprocess\n",
     "    import sys\n",

--- a/notebooks/multi_galaxy/features/pixelization/fit.ipynb
+++ b/notebooks/multi_galaxy/features/pixelization/fit.ipynb
@@ -349,16 +349,27 @@
     "\n",
     "The source reconstruction is held on the fit's `inversion`, as an array holding one flux value per source pixel.\n",
     "\n",
+    "The inversion's `reconstruction` is the solution vector over **every** linear object it solves, not just the source\n",
+    "pixels. Both deflectors here use `lp_linear` bulges, whose intensities are solved by the same linear algebra as the\n",
+    "source pixels, so `reconstruction` carries 2 entries more than the mesh has pixels. To count the source pixels, pull\n",
+    "the mapper out of the inversion's linear objects and read its own reconstruction.\n",
+    "\n",
     "The `subplot_fit_imaging` above already shows the reconstructed source alongside the data, model image and\n",
     "residuals. `imaging/features/pixelization/fit.py` covers the inversion's internals \u2014 its linear objects, mapping\n",
-    "matrices and grids \u2014 in full."
+    "matrices and grids \u2014 in full. That script uses standard light profiles, so its source is the only linear object and\n",
+    "this distinction does not arise."
    ]
   },
   {
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "print(f\"Number of source pixels reconstructed = {fit.inversion.reconstruction.shape[0]}\")"
+    "mapper = fit.inversion.cls_list_from(cls=al.Mapper)[0]\n",
+    "\n",
+    "print(\n",
+    "    f\"Number of source pixels reconstructed = \"\n",
+    "    f\"{fit.inversion.reconstruction_dict[mapper].shape[0]}\"\n",
+    ")"
    ],
    "outputs": [],
    "execution_count": null

--- a/notebooks/multi_galaxy/features/scaling_relation/slam.ipynb
+++ b/notebooks/multi_galaxy/features/scaling_relation/slam.ipynb
@@ -943,8 +943,25 @@
    "metadata": {},
    "source": [
     "dataset_name = \"scaling_relation\"\n",
-    "dataset_path = Path(\"dataset\") / \"multi_galaxy\" / dataset_name\n",
+    "dataset_path = Path(\"dataset\") / \"multi_galaxy\" / dataset_name"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Dataset Auto-Simulation__\n",
     "\n",
+    "If the dataset does not already exist on your system, it will be created by running the corresponding\n",
+    "simulator script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
     "if al.util.dataset.should_simulate(str(dataset_path)):\n",
     "    import subprocess\n",
     "    import sys\n",

--- a/scripts/multi_galaxy/features/extra_galaxies/slam.py
+++ b/scripts/multi_galaxy/features/extra_galaxies/slam.py
@@ -528,6 +528,12 @@ cannot reach — see `multi_galaxy/features/README.md` for that division of labo
 dataset_name = "extra_galaxies"
 dataset_path = Path("dataset") / "multi_galaxy" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
 if al.util.dataset.should_simulate(str(dataset_path)):
     import subprocess
     import sys

--- a/scripts/multi_galaxy/features/linear_light_profiles/slam.py
+++ b/scripts/multi_galaxy/features/linear_light_profiles/slam.py
@@ -457,6 +457,12 @@ The `simple` multi-galaxy dataset, set up exactly as in `multi_galaxy/slam.py`.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "multi_galaxy" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
 if al.util.dataset.should_simulate(str(dataset_path)):
     import subprocess
     import sys

--- a/scripts/multi_galaxy/features/multi_gaussian_expansion/slam.py
+++ b/scripts/multi_galaxy/features/multi_gaussian_expansion/slam.py
@@ -443,6 +443,12 @@ The `mge` dataset — the co-dominant pair with twisted, two-component light.
 dataset_name = "mge"
 dataset_path = Path("dataset") / "multi_galaxy" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
 if al.util.dataset.should_simulate(str(dataset_path)):
     import subprocess
     import sys

--- a/scripts/multi_galaxy/features/no_lens_light/slam.py
+++ b/scripts/multi_galaxy/features/no_lens_light/slam.py
@@ -386,6 +386,12 @@ contaminating galaxy — see the simulator's `__No Extra Galaxy__` note for why.
 dataset_name = "simple__no_lens_light"
 dataset_path = Path("dataset") / "multi_galaxy" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
 if al.util.dataset.should_simulate(str(dataset_path)):
     import subprocess
     import sys

--- a/scripts/multi_galaxy/features/pixelization/fit.py
+++ b/scripts/multi_galaxy/features/pixelization/fit.py
@@ -196,11 +196,22 @@ __Inversion__
 
 The source reconstruction is held on the fit's `inversion`, as an array holding one flux value per source pixel.
 
+The inversion's `reconstruction` is the solution vector over **every** linear object it solves, not just the source
+pixels. Both deflectors here use `lp_linear` bulges, whose intensities are solved by the same linear algebra as the
+source pixels, so `reconstruction` carries 2 entries more than the mesh has pixels. To count the source pixels, pull
+the mapper out of the inversion's linear objects and read its own reconstruction.
+
 The `subplot_fit_imaging` above already shows the reconstructed source alongside the data, model image and
 residuals. `imaging/features/pixelization/fit.py` covers the inversion's internals — its linear objects, mapping
-matrices and grids — in full.
+matrices and grids — in full. That script uses standard light profiles, so its source is the only linear object and
+this distinction does not arise.
 """
-print(f"Number of source pixels reconstructed = {fit.inversion.reconstruction.shape[0]}")
+mapper = fit.inversion.cls_list_from(cls=al.Mapper)[0]
+
+print(
+    f"Number of source pixels reconstructed = "
+    f"{fit.inversion.reconstruction_dict[mapper].shape[0]}"
+)
 
 """
 __Wrap Up__

--- a/scripts/multi_galaxy/features/scaling_relation/slam.py
+++ b/scripts/multi_galaxy/features/scaling_relation/slam.py
@@ -807,6 +807,12 @@ __Dataset__
 dataset_name = "scaling_relation"
 dataset_path = Path("dataset") / "multi_galaxy" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
 if al.util.dataset.should_simulate(str(dataset_path)):
     import subprocess
     import sys


### PR DESCRIPTION
Closes #438

Two small fixes in `scripts/multi_galaxy/`.

## 1 — source-pixel count was off by 2

`features/pixelization/fit.py` printed:

```python
print(f"Number of source pixels reconstructed = {fit.inversion.reconstruction.shape[0]}")
```

`inversion.reconstruction` is the solution vector over **every** linear object the inversion solves, not just the mapper. Both deflectors in this script use `al.lp_linear.Sersic` bulges, whose intensities are solved by the same linear algebra as the source pixels — so for a `(30, 30)` mesh the line read **902**.

`fit.py` is the only one of the four `features/pixelization/*.py` scripts that uses `lp_linear`; `delaunay.py`, `plot.py` and `source_science.py` have no linear light profiles, so their `len(reconstruction)` reads are correct as written. Those three already extract the mapper explicitly, and this now matches them:

```python
mapper = fit.inversion.cls_list_from(cls=al.Mapper)[0]

print(
    f"Number of source pixels reconstructed = "
    f"{fit.inversion.reconstruction_dict[mapper].shape[0]}"
)
```

The `__Inversion__` prose now explains why the two counts differ, and notes that the galaxy-scale walkthrough (`imaging/features/pixelization/fit.py`) cannot show the distinction — its source is the only linear object there. That felt worth teaching rather than silently correcting, since the whole point of this script is inspecting what the pixelization produces.

**Verified by running both versions on the same script:** unmodified `main` prints `902`, this branch prints `900` — exactly the two `lp_linear` bulges.

## 2 — five `slam.py` files missed the auto-sim header

Five of the eight `features/**/slam.py` files ran the auto-simulation block without introducing it with the standard `__Dataset Auto-Simulation__` section, so their generated notebooks showed a bare `subprocess.run` cell with no explanation.

| file | had header? |
|------|-------------|
| `extra_galaxies/slam.py` | no → **added** |
| `linear_light_profiles/slam.py` | no → **added** |
| `multi_gaussian_expansion/slam.py` | no → **added** |
| `no_lens_light/slam.py` | no → **added** |
| `scaling_relation/slam.py` | no → **added** |
| `pixelization/slam.py` | yes |
| `advanced/double_source_plane_lens/slam.py` | yes |
| `advanced/mass_stellar_dark/slam.py` | yes |

The code was already present and correct in all five — **this half is prose only, no behaviour change.** The header goes between `dataset_path` and the `should_simulate` call, splitting the existing `__Dataset__` section the same way `features/pixelization/fit.py` does.

## Verification

- `features/pixelization/fit.py` prints `900`, down from `902` on `main`.
- `grep -c '__Dataset Auto-Simulation__'` returns `1` for all eight `multi_galaxy/features/**/slam.py`.
- `scripts/check_sizes.sh` clean.
- Notebooks regenerated via PyAutoHands `generate.py autolens`.

## Scripts touched

- `scripts/multi_galaxy/features/pixelization/fit.py`
- `scripts/multi_galaxy/features/{extra_galaxies,linear_light_profiles,multi_gaussian_expansion,no_lens_light,scaling_relation}/slam.py`
- the six corresponding notebooks (regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)