### PR TITLE
fix: bound interferometer start_here memory with batch_size=4 (corrective for Heart RED)

### DIFF
--- a/notebooks/interferometer/start_here.ipynb
+++ b/notebooks/interferometer/start_here.ipynb
@@ -377,6 +377,7 @@
         "    name=\"start_here\",  # The name of the fit and folder results are output to.\n",
         "    unique_tag=dataset_name,  # A unique tag which also defines the folder.\n",
         "    n_starts=48,  # The number of independent optimizations run in parallel, increase for more complex models.\n",
+        "    batch_size=4,  # Starts evaluated at once: `None` vmaps all 48 together, which for interferometer datasets allocates tens of GB and can exhaust memory; small batches bound memory at some speed cost.\n",
         "    n_steps=300,  # The maximum gradient steps per start; the search stops early once the best fit stops improving.\n",
         "    iterations_per_quick_update=50,  # Every N steps the max likelihood model is visualized and output to hard-disk.\n",
         "    live_visual_update=False,  # Set True to open a live matplotlib window (script) or refresh a Jupyter cell (notebook).\n",

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -290,6 +290,7 @@ search = af.MultiStartProdigy(
     name="start_here",  # The name of the fit and folder results are output to.
     unique_tag=dataset_name,  # A unique tag which also defines the folder.
     n_starts=48,  # The number of independent optimizations run in parallel, increase for more complex models.
+    batch_size=4,  # Starts evaluated at once: `None` vmaps all 48 together, which for interferometer datasets allocates tens of GB and can exhaust memory; small batches bound memory at some speed cost.
     n_steps=300,  # The maximum gradient steps per start; the search stops early once the best fit stops improving.
     iterations_per_quick_update=50,  # Every N steps the max likelihood model is visualized and output to hard-disk.
     live_visual_update=False,  # Set True to open a live matplotlib window (script) or refresh a Jupyter cell (notebook).


### PR DESCRIPTION
Fixes #449. **Corrective PR for Heart RED reason (verbatim): `release validation FAILED (stage integrate)`** — human-authorized live on 2026-07-31 (record on #449).

## Scripts Changed

- `scripts/interferometer/start_here.py` — `batch_size=4` on `MultiStartProdigy` (+ regenerated notebook). Numerically identical to the unbatched vmap; bounds memory to one 4-start chunk's jvp instead of all 48 (~86 GB → <4 GB).

## Causal mapping, tests, validation plan

Full record on #449: integrate's only failing leg is this script's ~86 GB `RESOURCE_EXHAUSTED`; introduced by the 2026-07-29 post-release switch to MultiStartProdigy; control-vs-patched runs under the release-profile env reproduce the OOM and prove the fix (exit 0, ~5 min, <4 GB). Validation: tonight's nightly re-runs rehearse → integrate on fresh wheels; Heart's new verdict over that evidence is what clears the RED. This PR claims only the named RED reason — the sibling YELLOW (tenant firewall) is cleared by PyAutoHeart `feature/release-run-repo-slug-firewall`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DD69oa5NiimvmLZwLT3gWz