### PR TITLE
fix: declare ENV: full_datasets on potential-correction examples

### DIFF
--- a/scripts/imaging/features/advanced/potential_correction/likelihood_function.py
+++ b/scripts/imaging/features/advanced/potential_correction/likelihood_function.py
@@ -409,4 +409,24 @@ In a science analysis the regularization hyper-parameters are sampled with a non
 
 If you use this functionality, please cite Cao et al. 2025
 (https://github.com/caoxiaoyue/potential_correction_paper) alongside PyAutoLens.
+
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+This script simulates its dataset in-memory, so it does not need full_datasets
+for a shape match. It needs it for the same reason as this folder's
+start_here.py: the corrections mesh is built by subsampling the image grid, and
+under the SMALL_DATASETS cap al.pc.PairRegularDpsiMesh (dpsi_factor=2) can be
+starved to the point where mesh.py's get_itp_box_ctr raises "The dpsi grid is
+too sparse". Unlike its interferometer siblings this script does not currently
+fail capped — its arc mask happens to retain a valid interpolation box — but
+that is incidental, and config/build/profile_release.yaml already lifts the cap
+for this whole folder. Declaring it here keeps the smoke and release profiles
+in agreement instead of waiting for the coincidence to break.
+
+ENV: full_datasets
 """

--- a/scripts/interferometer/features/advanced/potential_correction/likelihood_function.py
+++ b/scripts/interferometer/features/advanced/potential_correction/likelihood_function.py
@@ -463,4 +463,22 @@ in this folder for the certified end-to-end recipe.
 
 If you use this functionality, please cite Cao et al. 2025
 (https://github.com/caoxiaoyue/potential_correction_paper) alongside PyAutoLens.
+
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+This script simulates its dataset in-memory, so it does not need full_datasets
+for a shape match. It needs it because the corrections mesh is built by
+subsampling the real-space mask: under the SMALL_DATASETS cap that mask is
+shrunk to 16x16, so al.pc.PairRegularDpsiMesh (dpsi_factor=2) has too few
+points and mesh.py's get_itp_box_ctr raises "The dpsi grid is too sparse".
+Uncapped this script runs in ~44s against the 300s smoke cap.
+config/build/profile_release.yaml carries the same reasoning for this folder
+and its imaging sibling.
+
+ENV: full_datasets
 """

--- a/scripts/interferometer/features/advanced/potential_correction/start_here.py
+++ b/scripts/interferometer/features/advanced/potential_correction/start_here.py
@@ -333,4 +333,21 @@ ranks over-fit and degenerate solutions below recovering ones, so evidence-drive
 
 If you use this functionality, please cite Cao et al. 2025
 (https://github.com/caoxiaoyue/potential_correction_paper) alongside PyAutoLens.
+
+__Env__ (Developer Only)
+
+Not user documentation: this section configures the automated test harness.
+The ENV line declares the environment applied when this script runs in CI
+(PyAutoHands docs/env_profile_redesign.md §10); this whole section is
+stripped from generated notebooks and markdown.
+
+This script simulates its dataset in-memory, so it does not need full_datasets
+for a shape match. It needs it because the corrections mesh is built by
+subsampling the real-space mask: under the SMALL_DATASETS cap that mask is
+shrunk to 16x16, so RegularDpsiMesh (factor=2) has too few points and mesh.py's
+get_itp_box_ctr raises "The dpsi grid is too sparse". Uncapped this script runs
+in ~83s against the 300s smoke cap. config/build/profile_release.yaml carries
+the same reasoning for this folder and its imaging sibling.
+
+ENV: full_datasets
 """


### PR DESCRIPTION
## Summary

Fixes the four workspace-smoke failures in `interferometer/features/advanced/potential_correction/`
(script and notebook of both examples), all raising
`ValueError: The dpsi grid is too sparse. Try decreasing the dpsi_factor to smaller values.`
— PyAutoHeart workspace-smoke run 30790463134.

**Root cause.** The smoke profile sets `PYAUTO_SMALL_DATASETS=1`, which shrinks `Mask2D.circular`
to 16x16 @ `pixel_scales=0.6` (`PyAutoArray/autoarray/mask/mask_2d.py:363`). With `dpsi_factor=2`
the dpsi mesh drops to 8x8, and after the arc restriction and `cleaned_mask_from` **zero** valid
2x2 interpolation boxes survive — so `get_itp_box_ctr` raises at
`PyAutoLens/autolens/potential_correction/mesh.py:132`.

**This is not drift from PyAutoLens#672.** The opt-out already existed everywhere else:

- `imaging/.../potential_correction/start_here.py` carries an `__Env__` section whose comment
  names *this exact error*, and adds that "profile_release.yaml carries the same reasoning for
  this folder and its interferometer sibling".
- `config/build/profile_release.yaml:58-61` has always lifted the cap for **both** folders.
- All 5 potential-correction scripts in `autolens_workspace_test` declare `ENV: full_datasets`.

Only the smoke path — which relies on in-file declarations since the #187 Stage 2 migration — was
missing them. The declaration reached the imaging guide in `5c1ce1d9` when it moved into
`features/`; the interferometer siblings never got the equivalent.

**Rejected alternatives.** Lowering `dpsi_factor` (factor=2 is the configuration certified by the
#672 validation campaign — dkappa correlation ~0.83, peak ~0.15" from truth, ~6 sigma — and at a
16x16 capped grid even factor=1 is scientifically meaningless); and loosening the library sparsity
check (it is correct at that resolution — relaxing it would silently build a degenerate mesh
instead of raising, against the no-silent-guards convention).

## Scripts Changed

- `scripts/interferometer/features/advanced/potential_correction/start_here.py` — add `__Env__` section declaring `ENV: full_datasets` (was failing smoke)
- `scripts/interferometer/features/advanced/potential_correction/likelihood_function.py` — same (was failing smoke)
- `scripts/imaging/features/advanced/potential_correction/likelihood_function.py` — same. Not currently failing: it passes capped only because its arc mask happens to retain a valid interpolation box. That is incidental and contradicts `profile_release.yaml`, which already lifts the cap for the whole folder — declaring it keeps the smoke and release profiles in agreement.

Docstring-only: 55 insertions, 0 deletions, no executable code touched.

## Test Plan

- [x] Both failing scripts reproduced under the exact CI smoke profile before the fix (identical traceback to run 30790463134)
- [x] All three changed scripts pass under that same profile after it — 59.5s / 42.2s / 17.6s against the 300s cap
- [x] `validate_env_profiles.py` clean (0 errors, 0 warnings)
- [x] Declarations confirmed to resolve to a released cap for all four scripts **and** their notebook mirrors (`.ipynb` maps back to its `.py` source for env resolution)
- [x] Notebook regeneration is a verified no-op — zero diff across `notebooks/`, `workspace_index.json`, `llms-full.txt` and `.script_sizes.json` (declarations are stripped from generated notebooks and the catalogue; 57 scripts carry one and 0 notebooks contain any trace)
- [ ] CI workspace-smoke confirms the four failures are cleared

**Note on local smoke coverage:** these four scripts are not listed in `smoke_tests.txt` /
`smoke_notebooks.txt`, so the local `/smoke_test` suite cannot exercise this change. The CI
matrix (`script_matrix.py`), which runs every script, is the real gate — the verification above
reproduces that exact invocation per-script.

Closes #457.

Generated by the PyAutoLabs agent workflow.
