### PR TITLE
fix: point_source/start_here composes PointSolved, matching its own prose

### DIFF
--- a/notebooks/point_source/start_here.ipynb
+++ b/notebooks/point_source/start_here.ipynb
@@ -289,7 +289,7 @@
         "\n",
         "# Source:\n",
         "\n",
-        "point_0 = af.Model(al.ps.Point)\n",
+        "point_0 = af.Model(al.ps.PointSolved)\n",
         "\n",
         "source = af.Model(al.Galaxy, redshift=0.658, point_0=point_0)\n",
         "\n",

--- a/scripts/point_source/start_here.py
+++ b/scripts/point_source/start_here.py
@@ -224,7 +224,7 @@ lens = af.Model(al.Galaxy, redshift=0.295, mass=mass)
 
 # Source:
 
-point_0 = af.Model(al.ps.Point)
+point_0 = af.Model(al.ps.PointSolved)
 
 source = af.Model(al.Galaxy, redshift=0.658, point_0=point_0)
 


### PR DESCRIPTION
Release-validation corrective. Blocks the current release.

## The bug

#453 switched this example to the solved-centre default but updated only **one of the two** model blocks in `scripts/point_source/start_here.py`. The prose at the top says:

> The source is composed as `al.ps.PointSolved` ... This is the recommended default

while the code twelve lines below still built `af.Model(al.ps.Point)`. The identical block later in the same file *was* updated. Prose and code contradicted each other.

Since PyAutoLens#686 made the solved all-to-all pairing the default, that stale line raises at fit time:

```
PointProfileMismatchException: The point-source profile paired to dataset
'point_0' (Point) has a `centre` attribute, so its free-centre priors would be
sampled by the non-linear search but silently ignored by
FitPositionsImagePairAllSolved ... Use a parameter-free profile
(e.g. ag.ps.PointSolved) with FitPositionsImagePairAllSolved
```

## Evidence it is a regression

| Run | `scripts/point_source/start_here.py` |
|---|---|
| [30788224561](https://github.com/PyAutoLabs/PyAutoHeart/actions/runs/30788224561) (pre-#686) | **passed** — 40.4s |
| [30842349506](https://github.com/PyAutoLabs/PyAutoHeart/actions/runs/30842349506) (post-#686) | **failed** — 4.5s |

Failing in 4.5s rather than 40s is the early raise, not a timeout. Reproduced locally under the release env profile built from `config/build/profile_release.yaml`, giving the traceback above.

## Change

One line — `af.Model(al.ps.Point)` → `af.Model(al.ps.PointSolved)` — plus the regenerated `notebooks/point_source/start_here.ipynb`. Regeneration touched only that notebook; `llms-full.txt` and `workspace_index.json` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)