### PR TITLE
fix: normalise the four hand-rolled auto-simulate guards onto should_simulate

### DIFF
--- a/notebooks/cluster/likelihood_function.ipynb
+++ b/notebooks/cluster/likelihood_function.ipynb
@@ -160,10 +160,31 @@
    "metadata": {},
    "source": [
     "dataset_name = \"simple\"\n",
-    "dataset_path = Path(\"dataset\") / \"cluster\" / dataset_name\n",
+    "dataset_path = Path(\"dataset\") / \"cluster\" / dataset_name"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Dataset Auto-Simulation__\n",
     "\n",
+    "If the dataset does not already exist on your system, it will be created by running the corresponding\n",
+    "simulator script. This ensures that all example scripts can be run without manually simulating data first.\n",
+    "\n",
+    "This script reads the truth model CSVs as well as the image, so it also checks ``mass.csv`` \u2014 a\n",
+    "directory left half-written by an interrupted simulator run must still trigger a rebuild.\n",
+    "``should_simulate`` is evaluated first so that its ``PYAUTO_SMALL_DATASETS`` rebuild always runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
     "if (\n",
-    "    not (dataset_path / \"data.fits\").exists()\n",
+    "    al.util.dataset.should_simulate(str(dataset_path))\n",
     "    or not (dataset_path / \"mass.csv\").exists()\n",
     "):\n",
     "    subprocess.run([sys.executable, \"scripts/cluster/simulator.py\"], check=True)\n",

--- a/notebooks/imaging/features/advanced/subhalo/sensitivity/slam_source_parametric.ipynb
+++ b/notebooks/imaging/features/advanced/subhalo/sensitivity/slam_source_parametric.ipynb
@@ -1002,7 +1002,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "if not dataset_Path().exists():\n",
+    "if al.util.dataset.should_simulate(str(dataset_path)):\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",

--- a/notebooks/imaging/features/advanced/subhalo/sensitivity/slam_source_pixelized.ipynb
+++ b/notebooks/imaging/features/advanced/subhalo/sensitivity/slam_source_pixelized.ipynb
@@ -1149,7 +1149,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "if not dataset_Path().exists():\n",
+    "if al.util.dataset.should_simulate(str(dataset_path)):\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",

--- a/notebooks/interferometer/features/pixelization/many_visibilities_preparation.ipynb
+++ b/notebooks/interferometer/features/pixelization/many_visibilities_preparation.ipynb
@@ -157,7 +157,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "if not (dataset_path / \"data.fits\").exists():\n",
+    "if al.util.dataset.should_simulate(str(dataset_path)):\n",
     "    subprocess.run(\n",
     "        [sys.executable, \"scripts/interferometer/simulator.py\"],\n",
     "        check=True,\n",

--- a/scripts/cluster/likelihood_function.py
+++ b/scripts/cluster/likelihood_function.py
@@ -103,8 +103,18 @@ likelihood.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "cluster" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+
+This script reads the truth model CSVs as well as the image, so it also checks ``mass.csv`` — a
+directory left half-written by an interrupted simulator run must still trigger a rebuild.
+``should_simulate`` is evaluated first so that its ``PYAUTO_SMALL_DATASETS`` rebuild always runs.
+"""
 if (
-    not (dataset_path / "data.fits").exists()
+    al.util.dataset.should_simulate(str(dataset_path))
     or not (dataset_path / "mass.csv").exists()
 ):
     subprocess.run([sys.executable, "scripts/cluster/simulator.py"], check=True)

--- a/scripts/imaging/features/advanced/subhalo/sensitivity/slam_source_parametric.py
+++ b/scripts/imaging/features/advanced/subhalo/sensitivity/slam_source_parametric.py
@@ -873,7 +873,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not dataset_Path().exists():
+if al.util.dataset.should_simulate(str(dataset_path)):
     import subprocess
     import sys
 

--- a/scripts/imaging/features/advanced/subhalo/sensitivity/slam_source_pixelized.py
+++ b/scripts/imaging/features/advanced/subhalo/sensitivity/slam_source_pixelized.py
@@ -1000,7 +1000,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not dataset_Path().exists():
+if al.util.dataset.should_simulate(str(dataset_path)):
     import subprocess
     import sys
 

--- a/scripts/interferometer/features/pixelization/many_visibilities_preparation.py
+++ b/scripts/interferometer/features/pixelization/many_visibilities_preparation.py
@@ -87,7 +87,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not (dataset_path / "data.fits").exists():
+if al.util.dataset.should_simulate(str(dataset_path)):
     subprocess.run(
         [sys.executable, "scripts/interferometer/simulator.py"],
         check=True,


### PR DESCRIPTION
Closes #462. Follow-up left open by choice from #455 / #460.

## What changed

Four scripts guarded their auto-simulate step by hand instead of calling `al.util.dataset.should_simulate`, which the other 249 sites use:

| Script | Before | After |
|---|---|---|
| `scripts/cluster/likelihood_function.py` | `not (dataset_path / "data.fits").exists() or not (dataset_path / "mass.csv").exists()` | `should_simulate(...) or not (dataset_path / "mass.csv").exists()` |
| `scripts/interferometer/features/pixelization/many_visibilities_preparation.py` | `not (dataset_path / "data.fits").exists()` | `should_simulate(...)` |
| `scripts/imaging/features/advanced/subhalo/sensitivity/slam_source_parametric.py` | `not dataset_Path().exists()` | `should_simulate(...)` |
| `scripts/imaging/features/advanced/subhalo/sensitivity/slam_source_pixelized.py` | `not dataset_Path().exists()` | `should_simulate(...)` |

The two idioms are not equivalent. Under `PYAUTO_SMALL_DATASETS=1` (a `config/build/profile_smoke.yaml` default) `should_simulate` deletes the dataset so the simulator rebuilds it at reduced resolution; a bare `.exists()` check reuses whatever is on disk. The four scripts therefore read a **full-resolution** dataset left by an earlier uncapped run inside a run that is meant to be capped.

`cluster/likelihood_function.py` also reads the truth-model CSVs, so its stricter `mass.csv` clause is **kept** rather than dropped. `should_simulate` is evaluated first so its rebuild side-effect always runs before `or` short-circuits.

## The failure mode is silent, not loud

The prompt (and this PR's first draft) predicted a shape-mismatch *crash*. Measured, it is quieter and worse. Controlled run of `cluster/likelihood_function.py` under the capped profile, with a stale **(1000, 1000)** dataset on disk, pre-change vs post-change — the only variable is whether the dataset gets rebuilt:

| | pre-change | post-change |
|---|---|---|
| dataset after run | **(1000, 1000)** — reused | **(16, 16)** — rebuilt |
| image-plane log likelihood | `-2.3951e+07` | `1.7518e+01` |
| library image-plane log likelihood | `-3.1784e+07` | `1.7518e+01` |
| script's own `Match (rtol=1e-2)` | **False** | **True** |
| process exit | **0** | 0 |

So a capped run silently computed on full-resolution data, the script's hand-rolled likelihood disagreed with the library's by ~33%, its own consistency check reported `False` — and it **exited 0 anyway**, so nothing surfaced it. A teaching script demonstrating a wrong result while reporting success. Running from an empty dataset dir gives `Match (rtol=1e-2): True`, confirming the stale dataset is the cause.

## Two of the four never worked at all

`slam_source_parametric.py` and `slam_source_pixelized.py` guarded on **`dataset_Path()`** — an undefined name — so they raised `NameError` whenever the dataset was absent. Confirmed before/after on a clean checkout:

```
BEFORE: NameError: name 'dataset_Path' is not defined. Did you mean: 'dataset_path'?   (line 876)
AFTER:  runs 98 lines further, to line 974
```

Nobody noticed because `config/build/no_run.yaml` excludes every sensitivity script, and **none of the four is in `smoke_tests.txt`** — so the premise that they "currently pass smoke" was wrong; they were never run.

Both still fail further down on **pre-existing, unrelated** stale-API faults — `'Model' object has no attribute 'centre'` (parametric) and `module 'autolens' has no attribute 'MapperValued'` (pixelized). Those are the standing `no_run` reason and are **out of scope**; this PR strictly improves both and does not claim to fix them.

## Verification

Capped profile (`PYAUTO_TEST_MODE=2 PYAUTO_SMALL_DATASETS=1` + the rest of `profile_smoke.yaml`), from an empty dataset dir **and** from a stale full-resolution one:

| Script | Case A (absent dir) | Case B (stale full-res) |
|---|---|---|
| `cluster/likelihood_function.py` | exit 0, 13.7s, `Match (rtol=1e-2): True` | exit 0, 11.8s, (1000,1000) → (16,16), `Match: True` |
| `interferometer/.../many_visibilities_preparation.py` | exit 0, 22.0s | exit 0, 18.3s, rebuilt (`data.fits` md5 `2d36bc69…` → `ee334711…`) |
| `subhalo/sensitivity/slam_source_parametric.py` | guard fires, dataset simulated, reaches line 974 (was `NameError` at 876) | n/a — `no_run` |
| `subhalo/sensitivity/slam_source_pixelized.py` | guard fires, dataset simulated | n/a — `no_run` |

Guard semantics isolated old-vs-new:

```
PYAUTO_SMALL_DATASETS=0   stale full-res -> old=False  new=False   (identical; uncapped runs unaffected)
PYAUTO_SMALL_DATASETS=1   stale full-res -> old=False  new=True    (old reuses full-res; new deletes + rebuilds)
```

Uncapped behaviour is unchanged, so the prompt's "can only make them slower" caution applies only to capped runs, where rebuilding is the point — and both timed cases are 12–22s.

Also run: `scripts/check_sizes.sh` (clean) and the full `run_smoke.py` suite.

## Scope note

Growing `should_simulate` an optional `required_files=[...]` argument (a PyAutoArray change) is **not done** — only 1 of 249 call sites needs a stricter check, so a library API for a single caller is not yet earned. Recorded on #462 rather than silently dropped.

A sweep confirms the class is now closed: no hand-rolled auto-simulate guards remain. The other `.exists()` checks in `scripts/` are deliberately different and were left alone — a `FileNotFoundError` for the committed SDP.81 dataset (`interferometer/start_here.py`), a path fallback (`guides/hpc/example_cpu_and_gpu.py`), and secondary-artifact guards (`positions.json`, `point_dataset_*.json`) that correctly sit *after* a primary `should_simulate` call (converting those would `rmtree` the dataset twice).

## Notebooks

Regenerated via PyAutoHands; exactly the four corresponding `.ipynb` files changed, diffs confined to the guard lines. Navigator catalogue (`llms-full.txt`, `workspace_index.json`) unchanged.