### PR TITLE
Update HowToLens chapter cross-references for the tutorial restructure

### DIFF
--- a/notebooks/imaging/features/advanced/double_source_plane_lens/modeling.ipynb
+++ b/notebooks/imaging/features/advanced/double_source_plane_lens/modeling.ipynb
@@ -324,7 +324,7 @@
     "For real data, we obviously do not know the true parameters and therefore cannot cheat in this way. Readers should\n",
     "checkout the **PyAutoLens**'s advanced feature `chaining`, which chains together multiple non-linear searches. \n",
     "\n",
-    "This feature is described in HowToLens chapter 3 and specific examples for a DSPL are given in\n",
+    "This feature is described in HowToLens chapter 2 (tutorials 9 and 10) and specific examples for a DSPL are given in\n",
     "the script `imaging/features/advanced/double_source_plane_lens/chaining.py`."
    ]
   },
@@ -570,10 +570,10 @@
     " - Basis based light profiles (e.g. `features/advanced/shapelets/modeling.ipynb` / `features/multi_gaussian_expansion/modeling.ipynb`): these allow one to fit\n",
     "   complex lens and source morphologies whilst keeping the dimensionality of the problem low.\n",
     "\n",
-    " - Search chaining (e.g. `guides/modeling/chaining` and HowToLens chapter 3): by breaking the model-fit into a series\n",
+    " - Search chaining (e.g. `guides/modeling/chaining` and HowToLens chapter 2, tutorials 9-10): by breaking the model-fit into a series\n",
     "   of Nautilus searches models of gradually increasing complexity can be fitted.\n",
     "\n",
-    " - pixelizations (e.g. `features/pixelization/modeling.ipynb` and HowToLens chapter 4): to infer the cosmological parameters reliably\n",
+    " - pixelizations (e.g. `features/pixelization/modeling.ipynb` and HowToLens chapter 3): to infer the cosmological parameters reliably\n",
     "   the source must be reconstructed on an adaptive mesh to capture a irregular morphological features."
    ]
   }

--- a/notebooks/imaging/features/pixelization/likelihood_function.ipynb
+++ b/notebooks/imaging/features/pixelization/likelihood_function.ipynb
@@ -537,7 +537,7 @@
     "the source-plane. \n",
     "\n",
     "We relocate these pixels (for both grids above) to the edge of the source-plane border (defined via the border of the \n",
-    "image-plane mask). This is detailed in **HowToLens chapter 4 tutorial 5** and figure 2 of https://arxiv.org/abs/1708.07377."
+    "image-plane mask). This is detailed in **HowToLens chapter 3 tutorial 6** and figure 2 of https://arxiv.org/abs/1708.07377."
    ]
   },
   {
@@ -1475,7 +1475,7 @@
     "`log_likelihood` to solutions which fit the data with a more smoothed and less complex source (e.g. one with a higher \n",
     "`regularization_coefficient`).\n",
     "\n",
-    "In **HowToLens** -> `chapter 4` -> `tutorial_4_bayesian_regularization` we expand on this further and give a more\n",
+    "In **HowToLens** -> `chapter 3` -> `tutorial_4_bayesian_regularization` we expand on this further and give a more\n",
     "detailed description of how these different terms impact the `log_likelihood_function`. "
    ]
   },

--- a/notebooks/interferometer/features/pixelization/likelihood_function.ipynb
+++ b/notebooks/interferometer/features/pixelization/likelihood_function.ipynb
@@ -428,7 +428,7 @@
     "the source-plane. \n",
     "\n",
     "We relocate these pixels (for both grids above) to the edge of the source-plane border (defined via the border of the \n",
-    "image-plane mask). This is detailed in **HowToLens chapter 4 tutorial 5** and figure 2 of https://arxiv.org/abs/1708.07377."
+    "image-plane mask). This is detailed in **HowToLens chapter 3 tutorial 6** and figure 2 of https://arxiv.org/abs/1708.07377."
    ]
   },
   {

--- a/scripts/imaging/features/advanced/double_source_plane_lens/modeling.py
+++ b/scripts/imaging/features/advanced/double_source_plane_lens/modeling.py
@@ -204,7 +204,7 @@ their true values. This is why the true `centre` values were input into the `mge
 For real data, we obviously do not know the true parameters and therefore cannot cheat in this way. Readers should
 checkout the **PyAutoLens**'s advanced feature `chaining`, which chains together multiple non-linear searches. 
 
-This feature is described in HowToLens chapter 3 and specific examples for a DSPL are given in
+This feature is described in HowToLens chapter 2 (tutorials 9 and 10) and specific examples for a DSPL are given in
 the script `imaging/features/advanced/double_source_plane_lens/chaining.py`.
 """
 lens.mass.centre_0 = af.GaussianPrior(mean=0.0, sigma=0.1)
@@ -351,9 +351,9 @@ to model a real DSPL:
  - Basis based light profiles (e.g. `features/advanced/shapelets/modeling.ipynb` / `features/multi_gaussian_expansion/modeling.ipynb`): these allow one to fit
    complex lens and source morphologies whilst keeping the dimensionality of the problem low.
 
- - Search chaining (e.g. `guides/modeling/chaining` and HowToLens chapter 3): by breaking the model-fit into a series
+ - Search chaining (e.g. `guides/modeling/chaining` and HowToLens chapter 2, tutorials 9-10): by breaking the model-fit into a series
    of Nautilus searches models of gradually increasing complexity can be fitted.
 
- - pixelizations (e.g. `features/pixelization/modeling.ipynb` and HowToLens chapter 4): to infer the cosmological parameters reliably
+ - pixelizations (e.g. `features/pixelization/modeling.ipynb` and HowToLens chapter 3): to infer the cosmological parameters reliably
    the source must be reconstructed on an adaptive mesh to capture a irregular morphological features.
 """

--- a/scripts/imaging/features/pixelization/likelihood_function.py
+++ b/scripts/imaging/features/pixelization/likelihood_function.py
@@ -309,7 +309,7 @@ Coordinates that are ray-traced near the mass profile centres are heavily demagn
 the source-plane. 
 
 We relocate these pixels (for both grids above) to the edge of the source-plane border (defined via the border of the 
-image-plane mask). This is detailed in **HowToLens chapter 4 tutorial 5** and figure 2 of https://arxiv.org/abs/1708.07377.
+image-plane mask). This is detailed in **HowToLens chapter 3 tutorial 6** and figure 2 of https://arxiv.org/abs/1708.07377.
 """
 from autoarray.inversion.mesh.border_relocator import BorderRelocator
 
@@ -897,7 +897,7 @@ These two terms therefore counteract the `chi_squared` and `regularization_term`
 `log_likelihood` to solutions which fit the data with a more smoothed and less complex source (e.g. one with a higher 
 `regularization_coefficient`).
 
-In **HowToLens** -> `chapter 4` -> `tutorial_4_bayesian_regularization` we expand on this further and give a more
+In **HowToLens** -> `chapter 3` -> `tutorial_4_bayesian_regularization` we expand on this further and give a more
 detailed description of how these different terms impact the `log_likelihood_function`. 
 """
 log_curvature_reg_matrix_term = np.linalg.slogdet(curvature_reg_matrix)[1]

--- a/scripts/interferometer/features/pixelization/likelihood_function.py
+++ b/scripts/interferometer/features/pixelization/likelihood_function.py
@@ -264,7 +264,7 @@ Coordinates that are ray-traced near the mass profile centres are heavily demagn
 the source-plane. 
 
 We relocate these pixels (for both grids above) to the edge of the source-plane border (defined via the border of the 
-image-plane mask). This is detailed in **HowToLens chapter 4 tutorial 5** and figure 2 of https://arxiv.org/abs/1708.07377.
+image-plane mask). This is detailed in **HowToLens chapter 3 tutorial 6** and figure 2 of https://arxiv.org/abs/1708.07377.
 """
 from autoarray.inversion.mesh.border_relocator import BorderRelocator
 


### PR DESCRIPTION
## Summary

Companion to PyAutoLabs/HowToLens#68: HowToLens dissolved its search-chaining chapter into chapter 2 (tutorials 9–11), renamed pixelizations to chapter 3 (borders now tutorial 6) and added a new chapter 4 on scaling up lensing. This updates the cross-references here to the new locations.

## Scripts touched

- `scripts/imaging/features/pixelization/likelihood_function.py` — "HowToLens chapter 4 tutorial 5" → chapter 3 tutorial 6 (borders); "chapter 4 → tutorial_4_bayesian_regularization" → chapter 3.
- `scripts/interferometer/features/pixelization/likelihood_function.py` — same borders reference fix.
- `scripts/imaging/features/advanced/double_source_plane_lens/modeling.py` — search-chaining references → chapter 2 tutorials 9–10; pixelizations reference → chapter 3.

Prose-only change, no code touched. The three matching notebooks were updated in place with the same text (verified valid JSON) rather than a full regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxKfSZisjnEn91LRGkN4SU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxKfSZisjnEn91LRGkN4SU)_