### PR TITLE
docs: fix 41 off-by-one script title underlines

### DIFF
--- a/notebooks/cluster/lenstool/parameterization_mapping.ipynb
+++ b/notebooks/cluster/lenstool/parameterization_mapping.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Lenstool Users: dPIE Parameterization Mapping (Scaling Galaxies)\n",
-    "===============================================================\n",
+    "================================================================\n",
     "\n",
     "**If you want to fit cluster member (scaling) galaxies without knowing the source or lens redshift,\n",
     "this script shows you how \u2014 and proves it recovers the standard Lenstool model exactly once the\n",

--- a/notebooks/cluster/likelihood_function.ipynb
+++ b/notebooks/cluster/likelihood_function.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Log Likelihood Function: Cluster Point Source\n",
-    "==============================================\n",
+    "=============================================\n",
     "\n",
     "This script provides a step-by-step guide of the cluster point-source ``log_likelihood_function``,\n",
     "the figure-of-merit Nautilus optimises when fitting a cluster lens model to ``point_datasets.csv``.\n",

--- a/notebooks/group/features/advanced/sky_background/fit.ipynb
+++ b/notebooks/group/features/advanced/sky_background/fit.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Fit Features: Sky Background (Group)\n",
-    "=====================================\n",
+    "====================================\n",
     "\n",
     "The background of an image is the light that is not associated with the strong lens we are interested in. This\n",
     "script demonstrates how to include the sky background in a fit for a group-scale strong lens, without performing\n",
@@ -79,7 +79,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/advanced/subhalo/detect/start_here.ipynb
+++ b/notebooks/group/features/advanced/subhalo/detect/start_here.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Subhalo Detection: Group\n",
-    "=========================\n",
+    "========================\n",
     "\n",
     "Strong gravitational lenses can be used to detect the presence of small-scale dark matter (DM) subhalos. This occurs\n",
     "when the DM subhalo overlaps the lensed source emission, and therefore gravitationally perturbs the observed image of\n",
@@ -102,7 +102,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/linear_light_profiles/slam.ipynb
+++ b/notebooks/group/features/linear_light_profiles/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Linear Light Profiles: Group SLaM\n",
-    "===================================\n",
+    "=================================\n",
     "\n",
     "This script uses the SLaM pipelines to fit a group-scale strong lens using **linear Sersic light profiles**\n",
     "instead of Multi-Gaussian Expansion (MGE) profiles for the galaxy light.\n",
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/multi_gaussian_expansion/fit.ipynb
+++ b/notebooks/group/features/multi_gaussian_expansion/fit.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Fit Features: Multi Gaussian Expansion (Group)\n",
-    "===============================================\n",
+    "==============================================\n",
     "\n",
     "This guide shows how to fit data using the `FitImaging` object for group-scale strong lenses, including visualizing\n",
     "and interpreting its results.\n",
@@ -77,7 +77,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/multi_gaussian_expansion/slam.ipynb
+++ b/notebooks/group/features/multi_gaussian_expansion/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Multi Gaussian Expansion: Group SLaM\n",
-    "=====================================\n",
+    "====================================\n",
     "\n",
     "This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for fitting a\n",
     "group-scale strong lens where all light profiles use Multi Gaussian Expansion (MGE) models.\n",
@@ -100,7 +100,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/pixelization/slam.ipynb
+++ b/notebooks/group/features/pixelization/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Pixelization: Group SLaM\n",
-    "=========================\n",
+    "========================\n",
     "\n",
     "This script uses the SLaM (Source, Light and Mass) pipelines to fit a group-scale strong lens where the\n",
     "source galaxy is reconstructed using a pixelized mesh with adaptive regularization.\n",
@@ -110,7 +110,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/results/aggregator/galaxies_fits.ipynb
+++ b/notebooks/guides/results/aggregator/galaxies_fits.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Results: Galaxies and Fits\n",
-    "===========================\n",
+    "==========================\n",
     "\n",
     "This tutorial inspects an inferred model using galaxies inferred by the non-linear search.\n",
     "This allows us to visualize and interpret its results.\n",
@@ -100,7 +100,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/advanced/los_halos/simulator_jax.ipynb
+++ b/notebooks/imaging/features/advanced/los_halos/simulator_jax.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Simulator: Line-of-Sight Halos (JAX)\n",
-    "=====================================\n",
+    "====================================\n",
     "\n",
     "This script simulates the same strong lens configuration as ``simulator.py`` \u2014 a galaxy-scale\n",
     "lens with line-of-sight (LOS) dark matter halos \u2014 but uses a JAX-accelerated path that compiles\n",
@@ -102,7 +102,7 @@
     "\n",
     "from autolens import jax_wrapper\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "import jax\n",

--- a/notebooks/imaging/features/advanced/mass_stellar_dark/slam.ipynb
+++ b/notebooks/imaging/features/advanced/mass_stellar_dark/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "SLaM (Source, Light and Mass): Mass Light Dark\n",
-    "===============================================\n",
+    "==============================================\n",
     "\n",
     "This example shows how to use the SLaM pipelines to end with a mass model which decomposes the lens into its\n",
     "stars and dark matter, using a light plus dark matter mass model.\n",
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/extra_galaxies/slam.ipynb
+++ b/notebooks/imaging/features/extra_galaxies/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Extra Galaxies: SLaM\n",
-    "=====================\n",
+    "====================\n",
     "\n",
     "This script uses the SLaM pipelines to fit a lens dataset that includes extra galaxies\n",
     "surrounding the main lens, whose light and mass are both included in the model.\n",
@@ -104,7 +104,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/linear_light_profiles/slam.ipynb
+++ b/notebooks/imaging/features/linear_light_profiles/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Linear Light Profiles: SLaM\n",
-    "============================\n",
+    "===========================\n",
     "\n",
     "This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines using linear light profiles\n",
     "for the lens galaxy's light.\n",
@@ -97,7 +97,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/no_lens_light/slam.ipynb
+++ b/notebooks/imaging/features/no_lens_light/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "No Lens Light: SLaM\n",
-    "====================\n",
+    "===================\n",
     "\n",
     "This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for fitting a\n",
     "lens model where there is no lens light observed in the imaging data.\n",
@@ -99,7 +99,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/interferometer/features/advanced/shapelets/fit.ipynb
+++ b/notebooks/interferometer/features/advanced/shapelets/fit.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling Features: Shapelets Fit (Interferometer)\n",
-    "==================================================\n",
+    "=================================================\n",
     "\n",
     "A shapelet is a basis function appropriate for capturing the exponential / disk-like features of a galaxy.\n",
     "The `intensity` of every shapelet is solved for via linear algebra (\"inversion\") rather than being a free\n",
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/interferometer/features/advanced/shapelets/modeling.ipynb
+++ b/notebooks/interferometer/features/advanced/shapelets/modeling.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling Features: Shapelets (Interferometer)\n",
-    "==============================================\n",
+    "=============================================\n",
     "\n",
     "A shapelet is a basis function appropriate for capturing the exponential / disk-like features of a galaxy.\n",
     "It has been employed in many strong lensing studies to model the light of the lensed source galaxy, because\n",
@@ -174,7 +174,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/interferometer/features/datacube/data_preparation.ipynb
+++ b/notebooks/interferometer/features/datacube/data_preparation.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Data Preparation: Datacube\n",
-    "============================\n",
+    "==========================\n",
     "\n",
     "Most users come to datacube modeling with a single 4D FITS file from CASA, with shape\n",
     "``(n_pol, n_chan, n_vis, 2)`` \u2014 for example, an ALMA observation of a CO emission line might be\n",
@@ -86,7 +86,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/interferometer/features/datacube/delaunay.ipynb
+++ b/notebooks/interferometer/features/datacube/delaunay.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling: Datacube \u2014 Delaunay Source\n",
-    "=====================================\n",
+    "====================================\n",
     "\n",
     "This script fits a datacube \u2014 a list of `Interferometer` channels \u2014 with a single shared lens model and a\n",
     "per-channel **Delaunay-pixelized** source reconstruction. It is the Delaunay sibling of `modeling.py`, which\n",
@@ -88,7 +88,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import subprocess\n",
     "import sys\n",

--- a/notebooks/interferometer/features/datacube/modeling.ipynb
+++ b/notebooks/interferometer/features/datacube/modeling.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling: Datacube\n",
-    "===================\n",
+    "==================\n",
     "\n",
     "This script fits a list of `Interferometer` channels \u2014 a \"datacube\" \u2014 with a single shared lens model and a\n",
     "per-channel pixelized source reconstruction. Each channel is an independent `Interferometer` dataset; the\n",
@@ -82,7 +82,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import subprocess\n",
     "import sys\n",

--- a/notebooks/interferometer/features/datacube/modeling_parametric.ipynb
+++ b/notebooks/interferometer/features/datacube/modeling_parametric.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling: Datacube \u2014 Parametric Source\n",
-    "=======================================\n",
+    "======================================\n",
     "\n",
     "This script fits a datacube \u2014 a list of `Interferometer` channels \u2014 with a single shared lens model and a\n",
     "**parametric** source (`al.lp.Sersic`) whose morphology is shared across channels and whose `intensity` varies\n",
@@ -89,7 +89,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import subprocess\n",
     "import sys\n",

--- a/notebooks/interferometer/features/datacube/simulator.ipynb
+++ b/notebooks/interferometer/features/datacube/simulator.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Simulator: Datacube\n",
-    "====================\n",
+    "===================\n",
     "\n",
     "This script simulates an ALMA-style spectral-line `Interferometer` datacube of a 'galaxy-scale' strong lens where:\n",
     "\n",
@@ -84,7 +84,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/extra_galaxies/slam.ipynb
+++ b/notebooks/interferometer/features/extra_galaxies/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Extra Galaxies: SLaM\n",
-    "=====================\n",
+    "====================\n",
     "\n",
     "This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for fitting a\n",
     "lens model where extra galaxies surrounding the lens are included in the lens model.\n",
@@ -133,7 +133,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/linear_light_profiles/fit.ipynb
+++ b/notebooks/interferometer/features/linear_light_profiles/fit.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling Features: Linear Light Profiles Fit (Interferometer)\n",
-    "==============================================================\n",
+    "=============================================================\n",
     "\n",
     "A \"linear light profile\" is a variant of a standard light profile where the `intensity` parameter is solved for\n",
     "via linear algebra every time the model is fitted to the data. This uses a process called an \"inversion\" and it\n",
@@ -121,7 +121,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/interferometer/features/linear_light_profiles/modeling.ipynb
+++ b/notebooks/interferometer/features/linear_light_profiles/modeling.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling Features: Linear Light Profiles (Interferometer)\n",
-    "==========================================================\n",
+    "=========================================================\n",
     "\n",
     "A \"linear light profile\" is a variant of a standard light profile where the `intensity` parameter is solved for\n",
     "via linear algebra every time the model is fitted to the data. This uses a process called an \"inversion\" and it\n",
@@ -166,7 +166,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/interferometer/features/linear_light_profiles/slam.ipynb
+++ b/notebooks/interferometer/features/linear_light_profiles/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Linear Light Profiles: SLaM (Interferometer)\n",
-    "=============================================\n",
+    "============================================\n",
     "\n",
     "This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for `Interferometer`\n",
     "data, using a **linear light profile** in the SOURCE LP stage instead of a Multi-Gaussian Expansion (MGE).\n",
@@ -135,7 +135,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/multi_gaussian_expansion/fit.ipynb
+++ b/notebooks/interferometer/features/multi_gaussian_expansion/fit.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling Features: Multi Gaussian Expansion Fit (Interferometer)\n",
-    "=================================================================\n",
+    "================================================================\n",
     "\n",
     "A multi-Gaussian expansion (MGE) decomposes a galaxy's light into ~15-100 Gaussians, where the `intensity`\n",
     "of every Gaussian is solved for via linear algebra using a process called an \"inversion\".\n",
@@ -106,7 +106,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/multi_gaussian_expansion/modeling.ipynb
+++ b/notebooks/interferometer/features/multi_gaussian_expansion/modeling.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling Features: Multi Gaussian Expansion (Interferometer)\n",
-    "=============================================================\n",
+    "============================================================\n",
     "\n",
     "A multi-Gaussian expansion (MGE) decomposes a galaxy's light into ~15-100 Gaussians, where the `intensity` of\n",
     "every Gaussian is solved for via linear algebra using a process called an \"inversion\" (see the\n",
@@ -165,7 +165,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/multi_gaussian_expansion/slam.ipynb
+++ b/notebooks/interferometer/features/multi_gaussian_expansion/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Multi Gaussian Expansion: SLaM (Interferometer)\n",
-    "================================================\n",
+    "===============================================\n",
     "\n",
     "This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for `Interferometer`\n",
     "data, using a **multi-Gaussian expansion (MGE)** for the source galaxy in the SOURCE LP stage.\n",
@@ -130,7 +130,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/scaling_relation/fit.ipynb
+++ b/notebooks/interferometer/features/scaling_relation/fit.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Features (Interferometer): Scaling Relation Fit\n",
-    "==============================================\n",
+    "===============================================\n",
     "\n",
     "Fits the interferometer `scaling_relation` dataset at the simulator's truth values, so the tied tier can be inspected\n",
     "without a non-linear search in the way.\n",
@@ -87,7 +87,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/scaling_relation/modeling.ipynb
+++ b/notebooks/interferometer/features/scaling_relation/modeling.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling Features (Interferometer): Scaling Relation\n",
-    "===================================================\n",
+    "====================================================\n",
     "\n",
     "Ties a population of foreground companions to the main lens's own Einstein radius by a Faber-Jackson relation, so\n",
     "the whole tier costs **zero free parameters**:\n",
@@ -105,7 +105,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/interferometer/features/scaling_relation/simulator.ipynb
+++ b/notebooks/interferometer/features/scaling_relation/simulator.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Simulator: Scaling Relation (Interferometer)\n",
-    "===========================================\n",
+    "============================================\n",
     "\n",
     "Simulates the dataset for the `interferometer/features/scaling_relation` feature: a lens plus a tier of foreground\n",
     "companions whose Einstein radii are tied to the main lens's own by a Faber-Jackson relation.\n",
@@ -88,7 +88,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/interferometer/features/scaling_relation/slam.ipynb
+++ b/notebooks/interferometer/features/scaling_relation/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Scaling Relation: SLaM (Interferometer)\n",
-    "======================================\n",
+    "=======================================\n",
     "\n",
     "Runs the SLaM pipelines on an interferometer dataset whose foreground companions are tied to the main lens's own\n",
     "Einstein radius by a Faber-Jackson relation.\n",
@@ -123,7 +123,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/interferometer/plot.ipynb
+++ b/notebooks/interferometer/plot.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Plots: Interferometer\n",
-    "======================\n",
+    "=====================\n",
     "\n",
     "This example shows how to plot an `Interferometer` dataset and a `FitInterferometer` fit, figure by figure and\n",
     "via multi-panel subplots.\n",
@@ -78,7 +78,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/scaling_relation/fit.ipynb
+++ b/notebooks/multi_galaxy/features/scaling_relation/fit.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Features (Multi Galaxy): Scaling Relation Fit\n",
-    "============================================\n",
+    "=============================================\n",
     "\n",
     "Fits the multi-galaxy `scaling_relation` dataset at the simulator's truth values, so the tied tier can be inspected\n",
     "without a non-linear search in the way.\n",
@@ -87,7 +87,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/features/scaling_relation/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/scaling_relation/modeling.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling Features (Multi Galaxy): Scaling Relation\n",
-    "=================================================\n",
+    "==================================================\n",
     "\n",
     "Extends the multi-galaxy model with a **scaling tier**: faint galaxies far from the co-dominant pair whose Einstein\n",
     "radii are tied to the brightest of the pair by a Faber-Jackson relation:\n",
@@ -123,7 +123,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/multi_galaxy/features/scaling_relation/simulator.ipynb
+++ b/notebooks/multi_galaxy/features/scaling_relation/simulator.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Simulator: Multi Galaxy Scaling Relation\n",
-    "=======================================\n",
+    "========================================\n",
     "\n",
     "Simulates the dataset for the `multi_galaxy/features/scaling_relation` feature: the co-dominant pair of\n",
     "`multi_galaxy/simulator.py`, plus five faint galaxies scattered FAR from the lens whose masses are tied to the\n",
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/multi_galaxy/features/scaling_relation/slam.ipynb
+++ b/notebooks/multi_galaxy/features/scaling_relation/slam.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Multi Galaxy Scaling Relation: SLaM\n",
-    "==================================\n",
+    "===================================\n",
     "\n",
     "Uses the SLaM pipelines to fit a multi-galaxy lens with a scaling tier whose Einstein radii are tied to the\n",
     "brightest co-dominant deflector.\n",
@@ -151,7 +151,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/plot.ipynb
+++ b/notebooks/multi_galaxy/plot.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Plots: Multi Galaxy\n",
-    "====================\n",
+    "===================\n",
     "\n",
     "This example shows how to plot a multi-galaxy `Imaging` dataset and a `FitImaging` fit, figure by figure and\n",
     "via multi-panel subplots.\n",
@@ -80,7 +80,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/point_source/features/scaling_relation/fit.ipynb
+++ b/notebooks/point_source/features/scaling_relation/fit.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Features (Point Source): Scaling Relation Fit\n",
-    "============================================\n",
+    "=============================================\n",
     "\n",
     "Fits the point-source `scaling_relation` dataset at the simulator's truth values, so the tied tier can be inspected\n",
     "without a non-linear search in the way.\n",
@@ -86,7 +86,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/point_source/features/scaling_relation/modeling.ipynb
+++ b/notebooks/point_source/features/scaling_relation/modeling.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Modeling Features (Point Source): Scaling Relation\n",
-    "=================================================\n",
+    "==================================================\n",
     "\n",
     "Ties a population of foreground companions to the lens's own Einstein radius by a Faber-Jackson relation, so the whole\n",
     "tier costs **zero free parameters**:\n",
@@ -113,7 +113,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/point_source/features/scaling_relation/simulator.ipynb
+++ b/notebooks/point_source/features/scaling_relation/simulator.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "Simulator: Scaling Relation (Point Source)\n",
-    "=========================================\n",
+    "==========================================\n",
     "\n",
     "Simulates the dataset for the `point_source/features/scaling_relation` feature: a quadruply imaged point source\n",
     "behind a lens with five foreground companions whose Einstein radii are tied to the lens's own by a Faber-Jackson\n",
@@ -97,7 +97,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/scripts/cluster/lenstool/parameterization_mapping.py
+++ b/scripts/cluster/lenstool/parameterization_mapping.py
@@ -1,6 +1,6 @@
 """
 Lenstool Users: dPIE Parameterization Mapping (Scaling Galaxies)
-===============================================================
+================================================================
 
 **If you want to fit cluster member (scaling) galaxies without knowing the source or lens redshift,
 this script shows you how — and proves it recovers the standard Lenstool model exactly once the

--- a/scripts/cluster/likelihood_function.py
+++ b/scripts/cluster/likelihood_function.py
@@ -1,6 +1,6 @@
 """
 Log Likelihood Function: Cluster Point Source
-==============================================
+=============================================
 
 This script provides a step-by-step guide of the cluster point-source ``log_likelihood_function``,
 the figure-of-merit Nautilus optimises when fitting a cluster lens model to ``point_datasets.csv``.

--- a/scripts/group/features/advanced/sky_background/fit.py
+++ b/scripts/group/features/advanced/sky_background/fit.py
@@ -1,6 +1,6 @@
 """
 Fit Features: Sky Background (Group)
-=====================================
+====================================
 
 The background of an image is the light that is not associated with the strong lens we are interested in. This
 script demonstrates how to include the sky background in a fit for a group-scale strong lens, without performing

--- a/scripts/group/features/advanced/subhalo/detect/start_here.py
+++ b/scripts/group/features/advanced/subhalo/detect/start_here.py
@@ -1,6 +1,6 @@
 """
 Subhalo Detection: Group
-=========================
+========================
 
 Strong gravitational lenses can be used to detect the presence of small-scale dark matter (DM) subhalos. This occurs
 when the DM subhalo overlaps the lensed source emission, and therefore gravitationally perturbs the observed image of

--- a/scripts/group/features/linear_light_profiles/slam.py
+++ b/scripts/group/features/linear_light_profiles/slam.py
@@ -1,6 +1,6 @@
 """
 Linear Light Profiles: Group SLaM
-===================================
+=================================
 
 This script uses the SLaM pipelines to fit a group-scale strong lens using **linear Sersic light profiles**
 instead of Multi-Gaussian Expansion (MGE) profiles for the galaxy light.

--- a/scripts/group/features/multi_gaussian_expansion/fit.py
+++ b/scripts/group/features/multi_gaussian_expansion/fit.py
@@ -1,6 +1,6 @@
 """
 Fit Features: Multi Gaussian Expansion (Group)
-===============================================
+==============================================
 
 This guide shows how to fit data using the `FitImaging` object for group-scale strong lenses, including visualizing
 and interpreting its results.

--- a/scripts/group/features/multi_gaussian_expansion/slam.py
+++ b/scripts/group/features/multi_gaussian_expansion/slam.py
@@ -1,6 +1,6 @@
 """
 Multi Gaussian Expansion: Group SLaM
-=====================================
+====================================
 
 This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for fitting a
 group-scale strong lens where all light profiles use Multi Gaussian Expansion (MGE) models.

--- a/scripts/group/features/pixelization/slam.py
+++ b/scripts/group/features/pixelization/slam.py
@@ -1,6 +1,6 @@
 """
 Pixelization: Group SLaM
-=========================
+========================
 
 This script uses the SLaM (Source, Light and Mass) pipelines to fit a group-scale strong lens where the
 source galaxy is reconstructed using a pixelized mesh with adaptive regularization.

--- a/scripts/guides/results/aggregator/galaxies_fits.py
+++ b/scripts/guides/results/aggregator/galaxies_fits.py
@@ -1,6 +1,6 @@
 """
 Results: Galaxies and Fits
-===========================
+==========================
 
 This tutorial inspects an inferred model using galaxies inferred by the non-linear search.
 This allows us to visualize and interpret its results.

--- a/scripts/imaging/features/advanced/los_halos/simulator_jax.py
+++ b/scripts/imaging/features/advanced/los_halos/simulator_jax.py
@@ -1,6 +1,6 @@
 """
 Simulator: Line-of-Sight Halos (JAX)
-=====================================
+====================================
 
 This script simulates the same strong lens configuration as ``simulator.py`` — a galaxy-scale
 lens with line-of-sight (LOS) dark matter halos — but uses a JAX-accelerated path that compiles

--- a/scripts/imaging/features/advanced/mass_stellar_dark/slam.py
+++ b/scripts/imaging/features/advanced/mass_stellar_dark/slam.py
@@ -1,6 +1,6 @@
 """
 SLaM (Source, Light and Mass): Mass Light Dark
-===============================================
+==============================================
 
 This example shows how to use the SLaM pipelines to end with a mass model which decomposes the lens into its
 stars and dark matter, using a light plus dark matter mass model.

--- a/scripts/imaging/features/extra_galaxies/slam.py
+++ b/scripts/imaging/features/extra_galaxies/slam.py
@@ -1,6 +1,6 @@
 """
 Extra Galaxies: SLaM
-=====================
+====================
 
 This script uses the SLaM pipelines to fit a lens dataset that includes extra galaxies
 surrounding the main lens, whose light and mass are both included in the model.

--- a/scripts/imaging/features/linear_light_profiles/slam.py
+++ b/scripts/imaging/features/linear_light_profiles/slam.py
@@ -1,6 +1,6 @@
 """
 Linear Light Profiles: SLaM
-============================
+===========================
 
 This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines using linear light profiles
 for the lens galaxy's light.

--- a/scripts/imaging/features/no_lens_light/slam.py
+++ b/scripts/imaging/features/no_lens_light/slam.py
@@ -1,6 +1,6 @@
 """
 No Lens Light: SLaM
-====================
+===================
 
 This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for fitting a
 lens model where there is no lens light observed in the imaging data.

--- a/scripts/interferometer/features/advanced/shapelets/fit.py
+++ b/scripts/interferometer/features/advanced/shapelets/fit.py
@@ -1,6 +1,6 @@
 """
 Modeling Features: Shapelets Fit (Interferometer)
-==================================================
+=================================================
 
 A shapelet is a basis function appropriate for capturing the exponential / disk-like features of a galaxy.
 The `intensity` of every shapelet is solved for via linear algebra ("inversion") rather than being a free

--- a/scripts/interferometer/features/advanced/shapelets/modeling.py
+++ b/scripts/interferometer/features/advanced/shapelets/modeling.py
@@ -1,6 +1,6 @@
 """
 Modeling Features: Shapelets (Interferometer)
-==============================================
+=============================================
 
 A shapelet is a basis function appropriate for capturing the exponential / disk-like features of a galaxy.
 It has been employed in many strong lensing studies to model the light of the lensed source galaxy, because

--- a/scripts/interferometer/features/datacube/data_preparation.py
+++ b/scripts/interferometer/features/datacube/data_preparation.py
@@ -1,6 +1,6 @@
 """
 Data Preparation: Datacube
-============================
+==========================
 
 Most users come to datacube modeling with a single 4D FITS file from CASA, with shape
 ``(n_pol, n_chan, n_vis, 2)`` — for example, an ALMA observation of a CO emission line might be

--- a/scripts/interferometer/features/datacube/delaunay.py
+++ b/scripts/interferometer/features/datacube/delaunay.py
@@ -1,6 +1,6 @@
 """
 Modeling: Datacube — Delaunay Source
-=====================================
+====================================
 
 This script fits a datacube — a list of `Interferometer` channels — with a single shared lens model and a
 per-channel **Delaunay-pixelized** source reconstruction. It is the Delaunay sibling of `modeling.py`, which

--- a/scripts/interferometer/features/datacube/modeling.py
+++ b/scripts/interferometer/features/datacube/modeling.py
@@ -1,6 +1,6 @@
 """
 Modeling: Datacube
-===================
+==================
 
 This script fits a list of `Interferometer` channels — a "datacube" — with a single shared lens model and a
 per-channel pixelized source reconstruction. Each channel is an independent `Interferometer` dataset; the

--- a/scripts/interferometer/features/datacube/modeling_parametric.py
+++ b/scripts/interferometer/features/datacube/modeling_parametric.py
@@ -1,6 +1,6 @@
 """
 Modeling: Datacube — Parametric Source
-=======================================
+======================================
 
 This script fits a datacube — a list of `Interferometer` channels — with a single shared lens model and a
 **parametric** source (`al.lp.Sersic`) whose morphology is shared across channels and whose `intensity` varies

--- a/scripts/interferometer/features/datacube/simulator.py
+++ b/scripts/interferometer/features/datacube/simulator.py
@@ -1,6 +1,6 @@
 """
 Simulator: Datacube
-====================
+===================
 
 This script simulates an ALMA-style spectral-line `Interferometer` datacube of a 'galaxy-scale' strong lens where:
 

--- a/scripts/interferometer/features/extra_galaxies/slam.py
+++ b/scripts/interferometer/features/extra_galaxies/slam.py
@@ -1,6 +1,6 @@
 """
 Extra Galaxies: SLaM
-=====================
+====================
 
 This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for fitting a
 lens model where extra galaxies surrounding the lens are included in the lens model.

--- a/scripts/interferometer/features/linear_light_profiles/fit.py
+++ b/scripts/interferometer/features/linear_light_profiles/fit.py
@@ -1,6 +1,6 @@
 """
 Modeling Features: Linear Light Profiles Fit (Interferometer)
-==============================================================
+=============================================================
 
 A "linear light profile" is a variant of a standard light profile where the `intensity` parameter is solved for
 via linear algebra every time the model is fitted to the data. This uses a process called an "inversion" and it

--- a/scripts/interferometer/features/linear_light_profiles/modeling.py
+++ b/scripts/interferometer/features/linear_light_profiles/modeling.py
@@ -1,6 +1,6 @@
 """
 Modeling Features: Linear Light Profiles (Interferometer)
-==========================================================
+=========================================================
 
 A "linear light profile" is a variant of a standard light profile where the `intensity` parameter is solved for
 via linear algebra every time the model is fitted to the data. This uses a process called an "inversion" and it

--- a/scripts/interferometer/features/linear_light_profiles/slam.py
+++ b/scripts/interferometer/features/linear_light_profiles/slam.py
@@ -1,6 +1,6 @@
 """
 Linear Light Profiles: SLaM (Interferometer)
-=============================================
+============================================
 
 This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for `Interferometer`
 data, using a **linear light profile** in the SOURCE LP stage instead of a Multi-Gaussian Expansion (MGE).

--- a/scripts/interferometer/features/multi_gaussian_expansion/fit.py
+++ b/scripts/interferometer/features/multi_gaussian_expansion/fit.py
@@ -1,6 +1,6 @@
 """
 Modeling Features: Multi Gaussian Expansion Fit (Interferometer)
-=================================================================
+================================================================
 
 A multi-Gaussian expansion (MGE) decomposes a galaxy's light into ~15-100 Gaussians, where the `intensity`
 of every Gaussian is solved for via linear algebra using a process called an "inversion".

--- a/scripts/interferometer/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/interferometer/features/multi_gaussian_expansion/modeling.py
@@ -1,6 +1,6 @@
 """
 Modeling Features: Multi Gaussian Expansion (Interferometer)
-=============================================================
+============================================================
 
 A multi-Gaussian expansion (MGE) decomposes a galaxy's light into ~15-100 Gaussians, where the `intensity` of
 every Gaussian is solved for via linear algebra using a process called an "inversion" (see the

--- a/scripts/interferometer/features/multi_gaussian_expansion/slam.py
+++ b/scripts/interferometer/features/multi_gaussian_expansion/slam.py
@@ -1,6 +1,6 @@
 """
 Multi Gaussian Expansion: SLaM (Interferometer)
-================================================
+===============================================
 
 This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for `Interferometer`
 data, using a **multi-Gaussian expansion (MGE)** for the source galaxy in the SOURCE LP stage.

--- a/scripts/interferometer/features/scaling_relation/fit.py
+++ b/scripts/interferometer/features/scaling_relation/fit.py
@@ -1,6 +1,6 @@
 """
 Features (Interferometer): Scaling Relation Fit
-==============================================
+===============================================
 
 Fits the interferometer `scaling_relation` dataset at the simulator's truth values, so the tied tier can be inspected
 without a non-linear search in the way.

--- a/scripts/interferometer/features/scaling_relation/modeling.py
+++ b/scripts/interferometer/features/scaling_relation/modeling.py
@@ -1,6 +1,6 @@
 """
 Modeling Features (Interferometer): Scaling Relation
-===================================================
+====================================================
 
 Ties a population of foreground companions to the main lens's own Einstein radius by a Faber-Jackson relation, so
 the whole tier costs **zero free parameters**:

--- a/scripts/interferometer/features/scaling_relation/simulator.py
+++ b/scripts/interferometer/features/scaling_relation/simulator.py
@@ -1,6 +1,6 @@
 """
 Simulator: Scaling Relation (Interferometer)
-===========================================
+============================================
 
 Simulates the dataset for the `interferometer/features/scaling_relation` feature: a lens plus a tier of foreground
 companions whose Einstein radii are tied to the main lens's own by a Faber-Jackson relation.

--- a/scripts/interferometer/features/scaling_relation/slam.py
+++ b/scripts/interferometer/features/scaling_relation/slam.py
@@ -1,6 +1,6 @@
 """
 Scaling Relation: SLaM (Interferometer)
-======================================
+=======================================
 
 Runs the SLaM pipelines on an interferometer dataset whose foreground companions are tied to the main lens's own
 Einstein radius by a Faber-Jackson relation.

--- a/scripts/interferometer/plot.py
+++ b/scripts/interferometer/plot.py
@@ -1,6 +1,6 @@
 """
 Plots: Interferometer
-======================
+=====================
 
 This example shows how to plot an `Interferometer` dataset and a `FitInterferometer` fit, figure by figure and
 via multi-panel subplots.

--- a/scripts/multi_galaxy/features/scaling_relation/fit.py
+++ b/scripts/multi_galaxy/features/scaling_relation/fit.py
@@ -1,6 +1,6 @@
 """
 Features (Multi Galaxy): Scaling Relation Fit
-============================================
+=============================================
 
 Fits the multi-galaxy `scaling_relation` dataset at the simulator's truth values, so the tied tier can be inspected
 without a non-linear search in the way.

--- a/scripts/multi_galaxy/features/scaling_relation/modeling.py
+++ b/scripts/multi_galaxy/features/scaling_relation/modeling.py
@@ -1,6 +1,6 @@
 """
 Modeling Features (Multi Galaxy): Scaling Relation
-=================================================
+==================================================
 
 Extends the multi-galaxy model with a **scaling tier**: faint galaxies far from the co-dominant pair whose Einstein
 radii are tied to the brightest of the pair by a Faber-Jackson relation:

--- a/scripts/multi_galaxy/features/scaling_relation/simulator.py
+++ b/scripts/multi_galaxy/features/scaling_relation/simulator.py
@@ -1,6 +1,6 @@
 """
 Simulator: Multi Galaxy Scaling Relation
-=======================================
+========================================
 
 Simulates the dataset for the `multi_galaxy/features/scaling_relation` feature: the co-dominant pair of
 `multi_galaxy/simulator.py`, plus five faint galaxies scattered FAR from the lens whose masses are tied to the

--- a/scripts/multi_galaxy/features/scaling_relation/slam.py
+++ b/scripts/multi_galaxy/features/scaling_relation/slam.py
@@ -1,6 +1,6 @@
 """
 Multi Galaxy Scaling Relation: SLaM
-==================================
+===================================
 
 Uses the SLaM pipelines to fit a multi-galaxy lens with a scaling tier whose Einstein radii are tied to the
 brightest co-dominant deflector.

--- a/scripts/multi_galaxy/plot.py
+++ b/scripts/multi_galaxy/plot.py
@@ -1,6 +1,6 @@
 """
 Plots: Multi Galaxy
-====================
+===================
 
 This example shows how to plot a multi-galaxy `Imaging` dataset and a `FitImaging` fit, figure by figure and
 via multi-panel subplots.

--- a/scripts/point_source/features/scaling_relation/fit.py
+++ b/scripts/point_source/features/scaling_relation/fit.py
@@ -1,6 +1,6 @@
 """
 Features (Point Source): Scaling Relation Fit
-============================================
+=============================================
 
 Fits the point-source `scaling_relation` dataset at the simulator's truth values, so the tied tier can be inspected
 without a non-linear search in the way.

--- a/scripts/point_source/features/scaling_relation/modeling.py
+++ b/scripts/point_source/features/scaling_relation/modeling.py
@@ -1,6 +1,6 @@
 """
 Modeling Features (Point Source): Scaling Relation
-=================================================
+==================================================
 
 Ties a population of foreground companions to the lens's own Einstein radius by a Faber-Jackson relation, so the whole
 tier costs **zero free parameters**:

--- a/scripts/point_source/features/scaling_relation/simulator.py
+++ b/scripts/point_source/features/scaling_relation/simulator.py
@@ -1,6 +1,6 @@
 """
 Simulator: Scaling Relation (Point Source)
-=========================================
+==========================================
 
 Simulates the dataset for the `point_source/features/scaling_relation` feature: a quadruply imaged point source
 behind a lens with five foreground companions whose Einstein radii are tied to the lens's own by a Faber-Jackson


### PR DESCRIPTION
Closes #476. PyAutoMind prompt: `active/script_title_underline_off_by_one.md`.

## What changed and why

Every workspace script opens with an RST-style title whose `===` rule should match the title's length. 41 scripts on `main` had a rule 1–2 characters off (the prompt's 2026-07-30 measurement at `726d060d` found 29; 12 more landed since with the scaling-relation and datacube feature families). Each fix is a one-line change setting the rule to exactly the title's length. Cosmetic in the scripts, but the titles flow into generated notebook markdown cells, so the mismatch was user-visible in rendered docs.

**Banner guard:** a rule differing from the line above by more than 2 characters is a deliberate full-width ASCII banner, not a typo. The classifier was control-tested against the prompt's reference commit `726d060d`, reproducing its recorded 29 typo / 15 banner split exactly, before being trusted on main. Current main has 14 banner rules (one block was removed upstream since); all 14 are byte-untouched here — re-running the classifier after the fix reports 0 remaining ≤2 mismatches and an unchanged banner count.

## Scripts touched (41, one line each)

<details>
<summary>Full list</summary>

- `scripts/cluster/lenstool/parameterization_mapping.py`
- `scripts/cluster/likelihood_function.py`
- `scripts/group/features/advanced/sky_background/fit.py`
- `scripts/group/features/advanced/subhalo/detect/start_here.py`
- `scripts/group/features/linear_light_profiles/slam.py`
- `scripts/group/features/multi_gaussian_expansion/fit.py`
- `scripts/group/features/multi_gaussian_expansion/slam.py`
- `scripts/group/features/pixelization/slam.py`
- `scripts/guides/results/aggregator/galaxies_fits.py`
- `scripts/imaging/features/advanced/los_halos/simulator_jax.py`
- `scripts/imaging/features/advanced/mass_stellar_dark/slam.py`
- `scripts/imaging/features/extra_galaxies/slam.py`
- `scripts/imaging/features/linear_light_profiles/slam.py`
- `scripts/imaging/features/no_lens_light/slam.py`
- `scripts/interferometer/features/advanced/shapelets/fit.py`
- `scripts/interferometer/features/advanced/shapelets/modeling.py`
- `scripts/interferometer/features/datacube/data_preparation.py`
- `scripts/interferometer/features/datacube/delaunay.py`
- `scripts/interferometer/features/datacube/modeling.py`
- `scripts/interferometer/features/datacube/modeling_parametric.py`
- `scripts/interferometer/features/datacube/simulator.py`
- `scripts/interferometer/features/extra_galaxies/slam.py`
- `scripts/interferometer/features/linear_light_profiles/fit.py`
- `scripts/interferometer/features/linear_light_profiles/modeling.py`
- `scripts/interferometer/features/linear_light_profiles/slam.py`
- `scripts/interferometer/features/multi_gaussian_expansion/fit.py`
- `scripts/interferometer/features/multi_gaussian_expansion/modeling.py`
- `scripts/interferometer/features/multi_gaussian_expansion/slam.py`
- `scripts/interferometer/features/scaling_relation/fit.py`
- `scripts/interferometer/features/scaling_relation/modeling.py`
- `scripts/interferometer/features/scaling_relation/simulator.py`
- `scripts/interferometer/features/scaling_relation/slam.py`
- `scripts/interferometer/plot.py`
- `scripts/multi_galaxy/features/scaling_relation/fit.py`
- `scripts/multi_galaxy/features/scaling_relation/modeling.py`
- `scripts/multi_galaxy/features/scaling_relation/simulator.py`
- `scripts/multi_galaxy/features/scaling_relation/slam.py`
- `scripts/multi_galaxy/plot.py`
- `scripts/point_source/features/scaling_relation/fit.py`
- `scripts/point_source/features/scaling_relation/modeling.py`
- `scripts/point_source/features/scaling_relation/simulator.py`

</details>

## Notebooks

The 41 paired notebooks were regenerated via PyAutoHands `generate.py autolens` and committed alongside the scripts. In 39 of them regeneration also brings the `setup_notebook()` line to current generator output (uncommented — the other 2 lack the line entirely).

**Pre-existing drift, deliberately not swept here:** a regeneration dry-run against *unmodified* scripts modifies 331 committed notebooks by that same one line — i.e. main's notebooks currently never call `setup_notebook()`. Filed as PyAutoMind `draft/maintenance/workspaces/notebook_setup_notebook_regen_drift.md` for a dedicated sweep; this PR only brings its own 41 notebooks to generator truth.

## Verification

- Classifier after fix: 0 remaining ≤2 mismatches; banner count unchanged (14)
- `check_navigator.py --root . --banners fail` green; navigator catalogue regenerated with zero diff (rules do not flow into summaries)
- `scripts/check_sizes.sh` green; all 41 scripts byte-compile
- Smoke suite: deferred to this PR's CI (no `autolens` install in the authoring session); change is docstring-only

## Could not update

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P99wpm73WoRjGx9eJs4ifV

---
_Generated by [Claude Code](https://claude.ai/code/session_01P99wpm73WoRjGx9eJs4ifV)_