### PR TITLE
build: repo-wide notebook sweep — activate setup_notebook in generated notebooks

### DIFF
--- a/notebooks/cluster/csv_api.ipynb
+++ b/notebooks/cluster/csv_api.ipynb
@@ -109,7 +109,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/cluster/modeling.ipynb
+++ b/notebooks/cluster/modeling.ipynb
@@ -132,7 +132,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/cluster/plot.ipynb
+++ b/notebooks/cluster/plot.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/cluster/simulator.ipynb
+++ b/notebooks/cluster/simulator.ipynb
@@ -229,7 +229,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import jax\n",
     "import jax.numpy as jnp\n",

--- a/notebooks/cluster/start_here.ipynb
+++ b/notebooks/cluster/start_here.ipynb
@@ -126,7 +126,7 @@
       "source": [
         "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
         "\n",
-        "# from autolens import setup_notebook; setup_notebook()\n",
+        "from autolens import setup_notebook; setup_notebook()\n",
         "\n",
         "import numpy as np\n",
         "from pathlib import Path\n",

--- a/notebooks/group/features/advanced/double_source_plane_lens/chaining.ipynb
+++ b/notebooks/group/features/advanced/double_source_plane_lens/chaining.ipynb
@@ -101,7 +101,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/advanced/double_source_plane_lens/fit.ipynb
+++ b/notebooks/group/features/advanced/double_source_plane_lens/fit.ipynb
@@ -85,7 +85,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/advanced/double_source_plane_lens/likelihood_function.ipynb
+++ b/notebooks/group/features/advanced/double_source_plane_lens/likelihood_function.ipynb
@@ -107,7 +107,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/advanced/double_source_plane_lens/modeling.ipynb
+++ b/notebooks/group/features/advanced/double_source_plane_lens/modeling.ipynb
@@ -86,7 +86,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/advanced/double_source_plane_lens/slam.ipynb
+++ b/notebooks/group/features/advanced/double_source_plane_lens/slam.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/advanced/mass_stellar_dark/chaining.ipynb
+++ b/notebooks/group/features/advanced/mass_stellar_dark/chaining.ipynb
@@ -102,7 +102,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/advanced/mass_stellar_dark/fit.ipynb
+++ b/notebooks/group/features/advanced/mass_stellar_dark/fit.ipynb
@@ -97,7 +97,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/advanced/mass_stellar_dark/likelihood_function.ipynb
+++ b/notebooks/group/features/advanced/mass_stellar_dark/likelihood_function.ipynb
@@ -114,7 +114,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/advanced/mass_stellar_dark/modeling.ipynb
+++ b/notebooks/group/features/advanced/mass_stellar_dark/modeling.ipynb
@@ -126,7 +126,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/advanced/mass_stellar_dark/simulator.ipynb
+++ b/notebooks/group/features/advanced/mass_stellar_dark/simulator.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/group/features/advanced/mass_stellar_dark/slam.ipynb
+++ b/notebooks/group/features/advanced/mass_stellar_dark/slam.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/advanced/operated_light_profile/modeling.ipynb
+++ b/notebooks/group/features/advanced/operated_light_profile/modeling.ipynb
@@ -89,7 +89,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/advanced/operated_light_profile/simulator.ipynb
+++ b/notebooks/group/features/advanced/operated_light_profile/simulator.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/advanced/shapelets/fit.ipynb
+++ b/notebooks/group/features/advanced/shapelets/fit.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/advanced/shapelets/modeling.ipynb
+++ b/notebooks/group/features/advanced/shapelets/modeling.ipynb
@@ -92,7 +92,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/advanced/sky_background/modeling.ipynb
+++ b/notebooks/group/features/advanced/sky_background/modeling.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/advanced/sky_background/simulator.ipynb
+++ b/notebooks/group/features/advanced/sky_background/simulator.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/advanced/subhalo/simulator.ipynb
+++ b/notebooks/group/features/advanced/subhalo/simulator.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/group_halo/modeling.ipynb
+++ b/notebooks/group/features/group_halo/modeling.ipynb
@@ -105,7 +105,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/group_halo/simulator.ipynb
+++ b/notebooks/group/features/group_halo/simulator.ipynb
@@ -86,7 +86,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/linear_light_profiles/fit.ipynb
+++ b/notebooks/group/features/linear_light_profiles/fit.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/linear_light_profiles/likelihood_function.ipynb
+++ b/notebooks/group/features/linear_light_profiles/likelihood_function.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/group/features/linear_light_profiles/modeling.ipynb
+++ b/notebooks/group/features/linear_light_profiles/modeling.ipynb
@@ -99,7 +99,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/multi_gaussian_expansion/likelihood_function.ipynb
+++ b/notebooks/group/features/multi_gaussian_expansion/likelihood_function.ipynb
@@ -79,7 +79,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/group/features/multi_gaussian_expansion/modeling.ipynb
+++ b/notebooks/group/features/multi_gaussian_expansion/modeling.ipynb
@@ -105,7 +105,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/multi_gaussian_expansion/simulator.ipynb
+++ b/notebooks/group/features/multi_gaussian_expansion/simulator.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/multi_gaussian_expansion/source_science.ipynb
+++ b/notebooks/group/features/multi_gaussian_expansion/source_science.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/no_lens_light/modeling.ipynb
+++ b/notebooks/group/features/no_lens_light/modeling.ipynb
@@ -99,7 +99,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/no_lens_light/simulator.ipynb
+++ b/notebooks/group/features/no_lens_light/simulator.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/no_lens_light/slam.ipynb
+++ b/notebooks/group/features/no_lens_light/slam.ipynb
@@ -106,7 +106,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/pixelization/adaptive.ipynb
+++ b/notebooks/group/features/pixelization/adaptive.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/pixelization/cpu_fast_modeling.ipynb
+++ b/notebooks/group/features/pixelization/cpu_fast_modeling.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/pixelization/delaunay.ipynb
+++ b/notebooks/group/features/pixelization/delaunay.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/pixelization/fit.ipynb
+++ b/notebooks/group/features/pixelization/fit.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/pixelization/likelihood_function.ipynb
+++ b/notebooks/group/features/pixelization/likelihood_function.ipynb
@@ -85,7 +85,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/group/features/pixelization/modeling.ipynb
+++ b/notebooks/group/features/pixelization/modeling.ipynb
@@ -85,7 +85,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/pixelization/source_science.ipynb
+++ b/notebooks/group/features/pixelization/source_science.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/scaling_relation/fit.ipynb
+++ b/notebooks/group/features/scaling_relation/fit.ipynb
@@ -101,7 +101,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/scaling_relation/likelihood_function.ipynb
+++ b/notebooks/group/features/scaling_relation/likelihood_function.ipynb
@@ -111,7 +111,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/scaling_relation/modeling.ipynb
+++ b/notebooks/group/features/scaling_relation/modeling.ipynb
@@ -123,7 +123,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/features/scaling_relation/modeling_for_luminosities.ipynb
+++ b/notebooks/group/features/scaling_relation/modeling_for_luminosities.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/features/scaling_relation/simulator.ipynb
+++ b/notebooks/group/features/scaling_relation/simulator.ipynb
@@ -65,7 +65,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/group/fit.ipynb
+++ b/notebooks/group/fit.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/likelihood_function.ipynb
+++ b/notebooks/group/likelihood_function.ipynb
@@ -97,7 +97,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/group/modeling.ipynb
+++ b/notebooks/group/modeling.ipynb
@@ -152,7 +152,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/group/plot.ipynb
+++ b/notebooks/group/plot.ipynb
@@ -79,7 +79,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/group/simulator.ipynb
+++ b/notebooks/group/simulator.ipynb
@@ -113,7 +113,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/slam.ipynb
+++ b/notebooks/group/slam.ipynb
@@ -154,7 +154,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/source_science.ipynb
+++ b/notebooks/group/source_science.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/group/start_here.ipynb
+++ b/notebooks/group/start_here.ipynb
@@ -117,7 +117,7 @@
       "source": [
         "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
         "\n",
-        "# from autolens import setup_notebook; setup_notebook()\n",
+        "from autolens import setup_notebook; setup_notebook()\n",
         "\n",
         "import numpy as np\n",
         "from pathlib import Path\n",

--- a/notebooks/guides/advanced/add_a_profile.ipynb
+++ b/notebooks/guides/advanced/add_a_profile.ipynb
@@ -89,7 +89,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "import autolens as al"

--- a/notebooks/guides/advanced/custom_analysis.ipynb
+++ b/notebooks/guides/advanced/custom_analysis.ipynb
@@ -112,7 +112,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/advanced/multi_plane.ipynb
+++ b/notebooks/guides/advanced/multi_plane.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from typing import List, Optional\n",
     "\n",

--- a/notebooks/guides/advanced/over_sampling.ipynb
+++ b/notebooks/guides/advanced/over_sampling.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/guides/advanced/over_sampling_chaining.ipynb
+++ b/notebooks/guides/advanced/over_sampling_chaining.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "import os\n",

--- a/notebooks/guides/coolest_interop.ipynb
+++ b/notebooks/guides/coolest_interop.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from os import path\n",
     "\n",

--- a/notebooks/guides/data_structures.ipynb
+++ b/notebooks/guides/data_structures.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/guides/galaxies.ipynb
+++ b/notebooks/guides/galaxies.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/guides/lens_calc.ipynb
+++ b/notebooks/guides/lens_calc.ipynb
@@ -115,7 +115,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "import autolens as al\n",

--- a/notebooks/guides/modeling/advanced/expectation_propagation.ipynb
+++ b/notebooks/guides/modeling/advanced/expectation_propagation.ipynb
@@ -89,7 +89,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import autolens as al\n",
     "import autofit as af\n",

--- a/notebooks/guides/modeling/advanced/graphical.ipynb
+++ b/notebooks/guides/modeling/advanced/graphical.ipynb
@@ -94,7 +94,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/modeling/advanced/hierarchical.ipynb
+++ b/notebooks/guides/modeling/advanced/hierarchical.ipynb
@@ -86,7 +86,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import autolens as al\n",
     "import autofit as af\n",

--- a/notebooks/guides/modeling/bug_fix.ipynb
+++ b/notebooks/guides/modeling/bug_fix.ipynb
@@ -93,7 +93,7 @@
     "        jax_wrapper,\n",
     "    )  # Ensures JAX environment variables are set before other imports\n",
     "\n",
-    "    # from autolens import setup_notebook; setup_notebook()\n",
+    "    from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "    from pathlib import Path\n",
     "    import autofit as af\n",

--- a/notebooks/guides/modeling/chaining.ipynb
+++ b/notebooks/guides/modeling/chaining.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/guides/modeling/cookbook.ipynb
+++ b/notebooks/guides/modeling/cookbook.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/guides/modeling/searches.ipynb
+++ b/notebooks/guides/modeling/searches.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/guides/modeling/slam_start_here.ipynb
+++ b/notebooks/guides/modeling/slam_start_here.ipynb
@@ -170,7 +170,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/plot/plotters.ipynb
+++ b/notebooks/guides/plot/plotters.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/guides/plot/searches.ipynb
+++ b/notebooks/guides/plot/searches.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/plot/start_here.ipynb
+++ b/notebooks/guides/plot/start_here.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/guides/plot/visuals.ipynb
+++ b/notebooks/guides/plot/visuals.ipynb
@@ -75,7 +75,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/guides/profiles/light.ipynb
+++ b/notebooks/guides/profiles/light.ipynb
@@ -111,7 +111,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import autofit as af\n",
     "import autolens as al\n",

--- a/notebooks/guides/profiles/light_and_mass_profiles.ipynb
+++ b/notebooks/guides/profiles/light_and_mass_profiles.ipynb
@@ -117,7 +117,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import autofit as af\n",
     "import autolens as al\n",

--- a/notebooks/guides/profiles/mass.ipynb
+++ b/notebooks/guides/profiles/mass.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "\n",

--- a/notebooks/guides/results/aggregator/data_fitting.ipynb
+++ b/notebooks/guides/results/aggregator/data_fitting.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import os\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/results/aggregator/models.ipynb
+++ b/notebooks/guides/results/aggregator/models.ipynb
@@ -66,7 +66,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import os\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/results/aggregator/queries.ipynb
+++ b/notebooks/guides/results/aggregator/queries.ipynb
@@ -68,7 +68,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/guides/results/aggregator/samples.ipynb
+++ b/notebooks/guides/results/aggregator/samples.ipynb
@@ -89,7 +89,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/guides/results/aggregator/samples_via_aggregator.ipynb
+++ b/notebooks/guides/results/aggregator/samples_via_aggregator.ipynb
@@ -97,7 +97,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/guides/results/database/start_here.ipynb
+++ b/notebooks/guides/results/database/start_here.ipynb
@@ -89,7 +89,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/guides/results/latent_variables.ipynb
+++ b/notebooks/guides/results/latent_variables.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/guides/results/start_here.ipynb
+++ b/notebooks/guides/results/start_here.ipynb
@@ -131,7 +131,7 @@
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "from autolens import from_json\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import os\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/results/workflow/csv_make.ipynb
+++ b/notebooks/guides/results/workflow/csv_make.ipynb
@@ -109,7 +109,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/guides/results/workflow/fits_make.ipynb
+++ b/notebooks/guides/results/workflow/fits_make.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/results/workflow/png_make.ipynb
+++ b/notebooks/guides/results/workflow/png_make.ipynb
@@ -121,7 +121,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/guides/tracer.ipynb
+++ b/notebooks/guides/tracer.ipynb
@@ -121,7 +121,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import autolens as al\n",
     "import autoarray as aa\n",

--- a/notebooks/guides/units/cosmology.ipynb
+++ b/notebooks/guides/units/cosmology.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/units/flux.ipynb
+++ b/notebooks/guides/units/flux.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/guides/using_jax.ipynb
+++ b/notebooks/guides/using_jax.ipynb
@@ -244,7 +244,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import jax\n",
     "import jax.numpy as jnp\n",

--- a/notebooks/imaging/data_preparation/examples/data.ipynb
+++ b/notebooks/imaging/data_preparation/examples/data.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/examples/noise_map.ipynb
+++ b/notebooks/imaging/data_preparation/examples/noise_map.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/examples/optional/extra_galaxies_centres.ipynb
+++ b/notebooks/imaging/data_preparation/examples/optional/extra_galaxies_centres.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/examples/optional/info.ipynb
+++ b/notebooks/imaging/data_preparation/examples/optional/info.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al"

--- a/notebooks/imaging/data_preparation/examples/optional/lens_light_centre.ipynb
+++ b/notebooks/imaging/data_preparation/examples/optional/lens_light_centre.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/examples/optional/mask.ipynb
+++ b/notebooks/imaging/data_preparation/examples/optional/mask.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/examples/optional/mask_extra_galaxies.ipynb
+++ b/notebooks/imaging/data_preparation/examples/optional/mask_extra_galaxies.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/imaging/data_preparation/examples/optional/positions.ipynb
+++ b/notebooks/imaging/data_preparation/examples/optional/positions.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/examples/psf.ipynb
+++ b/notebooks/imaging/data_preparation/examples/psf.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "# %matplotlib\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/data_preparation/gui/extra_galaxies_centres.ipynb
+++ b/notebooks/imaging/data_preparation/gui/extra_galaxies_centres.ipynb
@@ -70,7 +70,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/gui/lens_light_centre.ipynb
+++ b/notebooks/imaging/data_preparation/gui/lens_light_centre.ipynb
@@ -63,7 +63,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/gui/mask.ipynb
+++ b/notebooks/imaging/data_preparation/gui/mask.ipynb
@@ -65,7 +65,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/gui/mask_extra_galaxies.ipynb
+++ b/notebooks/imaging/data_preparation/gui/mask_extra_galaxies.ipynb
@@ -70,7 +70,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/gui/positions.ipynb
+++ b/notebooks/imaging/data_preparation/gui/positions.ipynb
@@ -65,7 +65,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/manual/mask_irregular.ipynb
+++ b/notebooks/imaging/data_preparation/manual/mask_irregular.ipynb
@@ -53,7 +53,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/data_preparation/start_here.ipynb
+++ b/notebooks/imaging/data_preparation/start_here.ipynb
@@ -80,7 +80,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/features/advanced/double_source_plane_lens/chaining.ipynb
+++ b/notebooks/imaging/features/advanced/double_source_plane_lens/chaining.ipynb
@@ -101,7 +101,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",
@@ -560,7 +560,7 @@
    "source": [
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/advanced/double_source_plane_lens/fit.ipynb
+++ b/notebooks/imaging/features/advanced/double_source_plane_lens/fit.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/advanced/double_source_plane_lens/likelihood_function.ipynb
+++ b/notebooks/imaging/features/advanced/double_source_plane_lens/likelihood_function.ipynb
@@ -107,7 +107,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/advanced/double_source_plane_lens/modeling.ipynb
+++ b/notebooks/imaging/features/advanced/double_source_plane_lens/modeling.ipynb
@@ -107,7 +107,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/advanced/double_source_plane_lens/plot.ipynb
+++ b/notebooks/imaging/features/advanced/double_source_plane_lens/plot.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/features/advanced/double_source_plane_lens/slam.ipynb
+++ b/notebooks/imaging/features/advanced/double_source_plane_lens/slam.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/advanced/los_halos/simulator.ipynb
+++ b/notebooks/imaging/features/advanced/los_halos/simulator.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/imaging/features/advanced/mass_stellar_dark/chaining.ipynb
+++ b/notebooks/imaging/features/advanced/mass_stellar_dark/chaining.ipynb
@@ -99,7 +99,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/advanced/mass_stellar_dark/fit.ipynb
+++ b/notebooks/imaging/features/advanced/mass_stellar_dark/fit.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/advanced/mass_stellar_dark/likelihood_function.ipynb
+++ b/notebooks/imaging/features/advanced/mass_stellar_dark/likelihood_function.ipynb
@@ -110,7 +110,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/advanced/mass_stellar_dark/modeling.ipynb
+++ b/notebooks/imaging/features/advanced/mass_stellar_dark/modeling.ipynb
@@ -134,7 +134,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/advanced/mass_stellar_dark/simulator.ipynb
+++ b/notebooks/imaging/features/advanced/mass_stellar_dark/simulator.ipynb
@@ -84,7 +84,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/features/advanced/operated_light_profile/modeling.ipynb
+++ b/notebooks/imaging/features/advanced/operated_light_profile/modeling.ipynb
@@ -108,7 +108,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/advanced/potential_correction/likelihood_function.ipynb
+++ b/notebooks/imaging/features/advanced/potential_correction/likelihood_function.ipynb
@@ -109,7 +109,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/imaging/features/advanced/shapelets/fit.ipynb
+++ b/notebooks/imaging/features/advanced/shapelets/fit.ipynb
@@ -121,7 +121,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/advanced/sky_background/fit.ipynb
+++ b/notebooks/imaging/features/advanced/sky_background/fit.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/advanced/sky_background/modeling.ipynb
+++ b/notebooks/imaging/features/advanced/sky_background/modeling.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/advanced/sky_background/simulator.ipynb
+++ b/notebooks/imaging/features/advanced/sky_background/simulator.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/features/advanced/subhalo/detect/database.ipynb
+++ b/notebooks/imaging/features/advanced/subhalo/detect/database.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "import os\n",

--- a/notebooks/imaging/features/advanced/subhalo/detect/start_here.ipynb
+++ b/notebooks/imaging/features/advanced/subhalo/detect/start_here.ipynb
@@ -143,7 +143,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/advanced/subhalo/sensitivity/slam_source_parametric.ipynb
+++ b/notebooks/imaging/features/advanced/subhalo/sensitivity/slam_source_parametric.ipynb
@@ -96,7 +96,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "import os\n",

--- a/notebooks/imaging/features/advanced/subhalo/sensitivity/slam_source_pixelized.ipynb
+++ b/notebooks/imaging/features/advanced/subhalo/sensitivity/slam_source_pixelized.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "import os\n",

--- a/notebooks/imaging/features/advanced/subhalo/sensitivity/start_here.ipynb
+++ b/notebooks/imaging/features/advanced/subhalo/sensitivity/start_here.ipynb
@@ -151,7 +151,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "import os\n",

--- a/notebooks/imaging/features/extra_galaxies/modeling.ipynb
+++ b/notebooks/imaging/features/extra_galaxies/modeling.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/linear_light_profiles/fit.ipynb
+++ b/notebooks/imaging/features/linear_light_profiles/fit.ipynb
@@ -123,7 +123,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/linear_light_profiles/likelihood_function.ipynb
+++ b/notebooks/imaging/features/linear_light_profiles/likelihood_function.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/imaging/features/linear_light_profiles/modeling.ipynb
+++ b/notebooks/imaging/features/linear_light_profiles/modeling.ipynb
@@ -129,7 +129,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/multi_gaussian_expansion/fit.ipynb
+++ b/notebooks/imaging/features/multi_gaussian_expansion/fit.ipynb
@@ -147,7 +147,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/multi_gaussian_expansion/likelihood_function.ipynb
+++ b/notebooks/imaging/features/multi_gaussian_expansion/likelihood_function.ipynb
@@ -96,7 +96,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/imaging/features/multi_gaussian_expansion/modeling.ipynb
+++ b/notebooks/imaging/features/multi_gaussian_expansion/modeling.ipynb
@@ -151,7 +151,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/multi_gaussian_expansion/slam.ipynb
+++ b/notebooks/imaging/features/multi_gaussian_expansion/slam.ipynb
@@ -98,7 +98,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/multi_gaussian_expansion/source_science.ipynb
+++ b/notebooks/imaging/features/multi_gaussian_expansion/source_science.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/no_lens_light/modeling.ipynb
+++ b/notebooks/imaging/features/no_lens_light/modeling.ipynb
@@ -108,7 +108,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/no_lens_light/simulator.ipynb
+++ b/notebooks/imaging/features/no_lens_light/simulator.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/features/pixelization/delaunay.ipynb
+++ b/notebooks/imaging/features/pixelization/delaunay.ipynb
@@ -138,7 +138,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",

--- a/notebooks/imaging/features/pixelization/fit.ipynb
+++ b/notebooks/imaging/features/pixelization/fit.ipynb
@@ -141,7 +141,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/pixelization/likelihood_function.ipynb
+++ b/notebooks/imaging/features/pixelization/likelihood_function.ipynb
@@ -111,7 +111,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/imaging/features/pixelization/plot.ipynb
+++ b/notebooks/imaging/features/pixelization/plot.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/features/pixelization/slam.ipynb
+++ b/notebooks/imaging/features/pixelization/slam.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/scaling_relation/fit.ipynb
+++ b/notebooks/imaging/features/scaling_relation/fit.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/scaling_relation/likelihood_function.ipynb
+++ b/notebooks/imaging/features/scaling_relation/likelihood_function.ipynb
@@ -111,7 +111,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/scaling_relation/modeling.ipynb
+++ b/notebooks/imaging/features/scaling_relation/modeling.ipynb
@@ -116,7 +116,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/imaging/features/scaling_relation/simulator.ipynb
+++ b/notebooks/imaging/features/scaling_relation/simulator.ipynb
@@ -101,7 +101,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/features/scaling_relation/slam.ipynb
+++ b/notebooks/imaging/features/scaling_relation/slam.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/features/simulator_manual_signal_to_noise_ratio.ipynb
+++ b/notebooks/imaging/features/simulator_manual_signal_to_noise_ratio.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/fit.ipynb
+++ b/notebooks/imaging/fit.ipynb
@@ -92,7 +92,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/likelihood_function.ipynb
+++ b/notebooks/imaging/likelihood_function.ipynb
@@ -92,7 +92,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/imaging/modeling.ipynb
+++ b/notebooks/imaging/modeling.ipynb
@@ -115,7 +115,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/plot.ipynb
+++ b/notebooks/imaging/plot.ipynb
@@ -79,7 +79,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/simulator.ipynb
+++ b/notebooks/imaging/simulator.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/imaging/simulator_sample.ipynb
+++ b/notebooks/imaging/simulator_sample.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/imaging/source_science.ipynb
+++ b/notebooks/imaging/source_science.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/imaging/start_here.ipynb
+++ b/notebooks/imaging/start_here.ipynb
@@ -105,7 +105,7 @@
       "source": [
         "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
         "\n",
-        "# from autolens import setup_notebook; setup_notebook()\n",
+        "from autolens import setup_notebook; setup_notebook()\n",
         "\n",
         "import numpy as np\n",
         "from pathlib import Path\n",
@@ -402,7 +402,7 @@
         "    name=\"start_here\",  # The name of the fit and folder results are output to.\n",
         "    unique_tag=dataset_name,  # A unique tag which also defines the folder.\n",
         "    n_starts=48,  # The number of independent optimizations run in parallel, increase for more complex models.\n",
-    "    batch_size=None,  # Starts evaluated at once: `None` vmaps all 48 together, which is fastest but allocates the whole batched gradient; set an integer (e.g. 4) if you hit an out-of-memory error.\n",
+        "    batch_size=None,  # Starts evaluated at once: `None` vmaps all 48 together, which is fastest but allocates the whole batched gradient; set an integer (e.g. 4) if you hit an out-of-memory error.\n",
         "    n_steps=300,  # The maximum gradient steps per start; the search stops early once the best fit stops improving.\n",
         "    iterations_per_quick_update=50,  # Every N steps the max likelihood model is visualized and output to hard-disk.\n",
         "    live_visual_update=True,  # Set True to open a live matplotlib window (script) or refresh a Jupyter cell (notebook).\n",

--- a/notebooks/interferometer/data_preparation.ipynb
+++ b/notebooks/interferometer/data_preparation.ipynb
@@ -93,7 +93,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/interferometer/features/advanced/potential_correction/likelihood_function.ipynb
+++ b/notebooks/interferometer/features/advanced/potential_correction/likelihood_function.ipynb
@@ -108,7 +108,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/interferometer/features/advanced/subhalo/detect/start_here.ipynb
+++ b/notebooks/interferometer/features/advanced/subhalo/detect/start_here.ipynb
@@ -150,7 +150,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/advanced/subhalo/sensitivity/start_here.ipynb
+++ b/notebooks/interferometer/features/advanced/subhalo/sensitivity/start_here.ipynb
@@ -74,7 +74,7 @@
     "# \"\"\"\n",
     "# from autolens import jax_wrapper # Ensures JAX environment variables are set before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "#\n",
     "# import numpy as np\n",
     "# from pathlib import Path\n",

--- a/notebooks/interferometer/features/advanced/subhalo/simulator.ipynb
+++ b/notebooks/interferometer/features/advanced/subhalo/simulator.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/interferometer/features/datacube/likelihood_function.ipynb
+++ b/notebooks/interferometer/features/datacube/likelihood_function.ipynb
@@ -136,7 +136,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/interferometer/features/datacube/start_here.ipynb
+++ b/notebooks/interferometer/features/datacube/start_here.ipynb
@@ -102,7 +102,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import subprocess\n",
     "import sys\n",

--- a/notebooks/interferometer/features/extra_galaxies/modeling.ipynb
+++ b/notebooks/interferometer/features/extra_galaxies/modeling.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/interferometer/features/linear_light_profiles/likelihood_function.ipynb
+++ b/notebooks/interferometer/features/linear_light_profiles/likelihood_function.ipynb
@@ -118,7 +118,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/interferometer/features/multi_gaussian_expansion/likelihood_function.ipynb
+++ b/notebooks/interferometer/features/multi_gaussian_expansion/likelihood_function.ipynb
@@ -107,7 +107,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/interferometer/features/pixelization/delaunay.ipynb
+++ b/notebooks/interferometer/features/pixelization/delaunay.ipynb
@@ -136,7 +136,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/interferometer/features/pixelization/fit.ipynb
+++ b/notebooks/interferometer/features/pixelization/fit.ipynb
@@ -144,7 +144,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/pixelization/likelihood_function.ipynb
+++ b/notebooks/interferometer/features/pixelization/likelihood_function.ipynb
@@ -117,7 +117,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/interferometer/features/pixelization/many_visibilities_preparation.ipynb
+++ b/notebooks/interferometer/features/pixelization/many_visibilities_preparation.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/pixelization/modeling.ipynb
+++ b/notebooks/interferometer/features/pixelization/modeling.ipynb
@@ -180,7 +180,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/pixelization/slam.ipynb
+++ b/notebooks/interferometer/features/pixelization/slam.ipynb
@@ -130,7 +130,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/pixelization/source_science.ipynb
+++ b/notebooks/interferometer/features/pixelization/source_science.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/features/scaling_relation/likelihood_function.ipynb
+++ b/notebooks/interferometer/features/scaling_relation/likelihood_function.ipynb
@@ -98,7 +98,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/fit.ipynb
+++ b/notebooks/interferometer/fit.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/likelihood_function.ipynb
+++ b/notebooks/interferometer/likelihood_function.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/interferometer/modeling.ipynb
+++ b/notebooks/interferometer/modeling.ipynb
@@ -106,7 +106,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/interferometer/simulator.ipynb
+++ b/notebooks/interferometer/simulator.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/interferometer/source_science.ipynb
+++ b/notebooks/interferometer/source_science.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/interferometer/start_here.ipynb
+++ b/notebooks/interferometer/start_here.ipynb
@@ -135,7 +135,7 @@
       "source": [
         "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
         "\n",
-        "# from autolens import setup_notebook; setup_notebook()\n",
+        "from autolens import setup_notebook; setup_notebook()\n",
         "\n",
         "from pathlib import Path\n",
         "import numpy as np\n",

--- a/notebooks/multi_dataset/features/dataset_offsets/modeling.ipynb
+++ b/notebooks/multi_dataset/features/dataset_offsets/modeling.ipynb
@@ -115,7 +115,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_dataset/features/dataset_offsets/simulator.ipynb
+++ b/notebooks/multi_dataset/features/dataset_offsets/simulator.ipynb
@@ -94,7 +94,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_dataset/features/imaging_and_interferometer/modeling.ipynb
+++ b/notebooks/multi_dataset/features/imaging_and_interferometer/modeling.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_dataset/features/imaging_and_interferometer/simulator.ipynb
+++ b/notebooks/multi_dataset/features/imaging_and_interferometer/simulator.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_dataset/features/imaging_and_point_source/modeling.ipynb
+++ b/notebooks/multi_dataset/features/imaging_and_point_source/modeling.ipynb
@@ -96,7 +96,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_dataset/features/one_by_one/modeling.ipynb
+++ b/notebooks/multi_dataset/features/one_by_one/modeling.ipynb
@@ -108,7 +108,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_dataset/features/pixelization/simulator.ipynb
+++ b/notebooks/multi_dataset/features/pixelization/simulator.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_dataset/features/same_wavelength/modeling.ipynb
+++ b/notebooks/multi_dataset/features/same_wavelength/modeling.ipynb
@@ -79,7 +79,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_dataset/features/same_wavelength/simulator.ipynb
+++ b/notebooks/multi_dataset/features/same_wavelength/simulator.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_dataset/features/slam/independent.ipynb
+++ b/notebooks/multi_dataset/features/slam/independent.ipynb
@@ -130,7 +130,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_dataset/features/slam/simultaneous.ipynb
+++ b/notebooks/multi_dataset/features/slam/simultaneous.ipynb
@@ -113,7 +113,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_dataset/features/wavelength_dependence/modeling.ipynb
+++ b/notebooks/multi_dataset/features/wavelength_dependence/modeling.ipynb
@@ -89,7 +89,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/multi_dataset/features/wavelength_dependence/simulator.ipynb
+++ b/notebooks/multi_dataset/features/wavelength_dependence/simulator.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_dataset/modeling.ipynb
+++ b/notebooks/multi_dataset/modeling.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_dataset/plot.ipynb
+++ b/notebooks/multi_dataset/plot.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_dataset/simulator.ipynb
+++ b/notebooks/multi_dataset/simulator.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_dataset/start_here.ipynb
+++ b/notebooks/multi_dataset/start_here.ipynb
@@ -108,7 +108,7 @@
       "source": [
         "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
         "\n",
-        "# from autolens import setup_notebook; setup_notebook()\n",
+        "from autolens import setup_notebook; setup_notebook()\n",
         "\n",
         "import numpy as np\n",
         "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/chaining.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/chaining.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/fit.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/fit.ipynb
@@ -92,7 +92,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/likelihood_function.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/likelihood_function.ipynb
@@ -101,7 +101,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/modeling.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/simulator.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/simulator.ipynb
@@ -94,7 +94,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/slam.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/double_source_plane_lens/slam.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/chaining.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/chaining.ipynb
@@ -98,7 +98,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/fit.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/fit.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/likelihood_function.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/likelihood_function.ipynb
@@ -98,7 +98,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/modeling.ipynb
@@ -123,7 +123,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/simulator.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/simulator.ipynb
@@ -92,7 +92,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/slam.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/mass_stellar_dark/slam.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/advanced/operated_light_profile/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/operated_light_profile/modeling.ipynb
@@ -122,7 +122,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/advanced/operated_light_profile/simulator.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/operated_light_profile/simulator.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/advanced/shapelets/fit.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/shapelets/fit.ipynb
@@ -86,7 +86,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/advanced/shapelets/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/shapelets/modeling.ipynb
@@ -131,7 +131,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/advanced/sky_background/fit.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/sky_background/fit.ipynb
@@ -84,7 +84,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/advanced/sky_background/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/sky_background/modeling.ipynb
@@ -115,7 +115,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/advanced/sky_background/simulator.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/sky_background/simulator.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/advanced/subhalo/detect/start_here.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/subhalo/detect/start_here.ipynb
@@ -112,7 +112,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/advanced/subhalo/simulator.ipynb
+++ b/notebooks/multi_galaxy/features/advanced/subhalo/simulator.ipynb
@@ -99,7 +99,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/extra_galaxies/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/extra_galaxies/modeling.ipynb
@@ -115,7 +115,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/multi_galaxy/features/extra_galaxies/simulator.ipynb
+++ b/notebooks/multi_galaxy/features/extra_galaxies/simulator.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/multi_galaxy/features/extra_galaxies/slam.ipynb
+++ b/notebooks/multi_galaxy/features/extra_galaxies/slam.ipynb
@@ -116,7 +116,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/linear_light_profiles/fit.ipynb
+++ b/notebooks/multi_galaxy/features/linear_light_profiles/fit.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/linear_light_profiles/likelihood_function.ipynb
+++ b/notebooks/multi_galaxy/features/linear_light_profiles/likelihood_function.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import matplotlib.pyplot as plt\n",

--- a/notebooks/multi_galaxy/features/linear_light_profiles/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/linear_light_profiles/modeling.ipynb
@@ -142,7 +142,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/linear_light_profiles/slam.ipynb
+++ b/notebooks/multi_galaxy/features/linear_light_profiles/slam.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/multi_gaussian_expansion/fit.ipynb
+++ b/notebooks/multi_galaxy/features/multi_gaussian_expansion/fit.ipynb
@@ -79,7 +79,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/multi_galaxy/features/multi_gaussian_expansion/likelihood_function.ipynb
+++ b/notebooks/multi_galaxy/features/multi_gaussian_expansion/likelihood_function.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import matplotlib.pyplot as plt\n",

--- a/notebooks/multi_galaxy/features/multi_gaussian_expansion/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/multi_gaussian_expansion/modeling.ipynb
@@ -172,7 +172,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/multi_gaussian_expansion/simulator.ipynb
+++ b/notebooks/multi_galaxy/features/multi_gaussian_expansion/simulator.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/multi_gaussian_expansion/slam.ipynb
+++ b/notebooks/multi_galaxy/features/multi_gaussian_expansion/slam.ipynb
@@ -94,7 +94,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/multi_gaussian_expansion/source_science.ipynb
+++ b/notebooks/multi_galaxy/features/multi_gaussian_expansion/source_science.ipynb
@@ -85,7 +85,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/multi_galaxy/features/no_lens_light/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/no_lens_light/modeling.ipynb
@@ -129,7 +129,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/no_lens_light/simulator.ipynb
+++ b/notebooks/multi_galaxy/features/no_lens_light/simulator.ipynb
@@ -98,7 +98,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/no_lens_light/slam.ipynb
+++ b/notebooks/multi_galaxy/features/no_lens_light/slam.ipynb
@@ -102,7 +102,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/pixelization/adaptive.ipynb
+++ b/notebooks/multi_galaxy/features/pixelization/adaptive.ipynb
@@ -102,7 +102,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/pixelization/cpu_fast_modeling.ipynb
+++ b/notebooks/multi_galaxy/features/pixelization/cpu_fast_modeling.ipynb
@@ -112,7 +112,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/pixelization/delaunay.ipynb
+++ b/notebooks/multi_galaxy/features/pixelization/delaunay.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/features/pixelization/fit.ipynb
+++ b/notebooks/multi_galaxy/features/pixelization/fit.ipynb
@@ -75,7 +75,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/pixelization/likelihood_function.ipynb
+++ b/notebooks/multi_galaxy/features/pixelization/likelihood_function.ipynb
@@ -94,7 +94,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/multi_galaxy/features/pixelization/modeling.ipynb
+++ b/notebooks/multi_galaxy/features/pixelization/modeling.ipynb
@@ -114,7 +114,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/pixelization/plot.ipynb
+++ b/notebooks/multi_galaxy/features/pixelization/plot.ipynb
@@ -79,7 +79,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/multi_galaxy/features/pixelization/slam.ipynb
+++ b/notebooks/multi_galaxy/features/pixelization/slam.ipynb
@@ -106,7 +106,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/features/pixelization/source_science.ipynb
+++ b/notebooks/multi_galaxy/features/pixelization/source_science.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/features/scaling_relation/likelihood_function.ipynb
+++ b/notebooks/multi_galaxy/features/scaling_relation/likelihood_function.ipynb
@@ -104,7 +104,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/fit.ipynb
+++ b/notebooks/multi_galaxy/fit.ipynb
@@ -104,7 +104,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/likelihood_function.ipynb
+++ b/notebooks/multi_galaxy/likelihood_function.ipynb
@@ -102,7 +102,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/modeling.ipynb
+++ b/notebooks/multi_galaxy/modeling.ipynb
@@ -157,7 +157,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/simulator.ipynb
+++ b/notebooks/multi_galaxy/simulator.ipynb
@@ -113,7 +113,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/simulator_sample.ipynb
+++ b/notebooks/multi_galaxy/simulator_sample.ipynb
@@ -97,7 +97,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/multi_galaxy/slam.ipynb
+++ b/notebooks/multi_galaxy/slam.ipynb
@@ -125,7 +125,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/multi_galaxy/source_science.ipynb
+++ b/notebooks/multi_galaxy/source_science.ipynb
@@ -80,7 +80,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/multi_galaxy/start_here.ipynb
+++ b/notebooks/multi_galaxy/start_here.ipynb
@@ -122,7 +122,7 @@
       "source": [
         "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
         "\n",
-        "# from autolens import setup_notebook; setup_notebook()\n",
+        "from autolens import setup_notebook; setup_notebook()\n",
         "\n",
         "from pathlib import Path\n",
         "\n",
@@ -475,7 +475,7 @@
         "    name=\"start_here\",  # The name of the fit and folder results are output to.\n",
         "    unique_tag=dataset_name,  # A unique tag which also defines the folder.\n",
         "    n_starts=48,  # The number of independent optimizations run in parallel, increase for more complex models.\n",
-    "    batch_size=None,  # Starts evaluated at once: `None` vmaps all 48 together, which is fastest but allocates the whole batched gradient; set an integer (e.g. 4) if you hit an out-of-memory error.\n",
+        "    batch_size=None,  # Starts evaluated at once: `None` vmaps all 48 together, which is fastest but allocates the whole batched gradient; set an integer (e.g. 4) if you hit an out-of-memory error.\n",
         "    n_steps=300,  # The maximum gradient steps per start; the search stops early once the best fit stops improving.\n",
         "    iterations_per_quick_update=50,  # Every N steps the max likelihood model is visualized and output to hard-disk.\n",
         "    live_visual_update=True,  # Set True to open a live matplotlib window (script) or refresh a Jupyter cell (notebook).\n",

--- a/notebooks/point_source/features/deblending/modeling.ipynb
+++ b/notebooks/point_source/features/deblending/modeling.ipynb
@@ -146,7 +146,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/point_source/features/deblending/simulator.ipynb
+++ b/notebooks/point_source/features/deblending/simulator.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/point_source/features/extra_galaxies/modeling.ipynb
+++ b/notebooks/point_source/features/extra_galaxies/modeling.ipynb
@@ -123,7 +123,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/point_source/features/extra_galaxies/simulator.ipynb
+++ b/notebooks/point_source/features/extra_galaxies/simulator.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/point_source/features/fluxes.ipynb
+++ b/notebooks/point_source/features/fluxes.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/point_source/features/multiple_sources/modeling.ipynb
+++ b/notebooks/point_source/features/multiple_sources/modeling.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/point_source/features/multiple_sources/simulator.ipynb
+++ b/notebooks/point_source/features/multiple_sources/simulator.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/point_source/features/scaling_relation/likelihood_function.ipynb
+++ b/notebooks/point_source/features/scaling_relation/likelihood_function.ipynb
@@ -97,7 +97,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/point_source/features/time_delays.ipynb
+++ b/notebooks/point_source/features/time_delays.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/point_source/fit.ipynb
+++ b/notebooks/point_source/fit.ipynb
@@ -106,7 +106,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/point_source/modeling.ipynb
+++ b/notebooks/point_source/modeling.ipynb
@@ -105,7 +105,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autofit as af\n",

--- a/notebooks/point_source/plot.ipynb
+++ b/notebooks/point_source/plot.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/point_source/simulator.ipynb
+++ b/notebooks/point_source/simulator.ipynb
@@ -86,7 +86,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import numpy as np\n",

--- a/notebooks/point_source/simulator_sample.ipynb
+++ b/notebooks/point_source/simulator_sample.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/point_source/start_here.ipynb
+++ b/notebooks/point_source/start_here.ipynb
@@ -116,7 +116,7 @@
       "source": [
         "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
         "\n",
-        "# from autolens import setup_notebook; setup_notebook()\n",
+        "from autolens import setup_notebook; setup_notebook()\n",
         "\n",
         "import numpy as np\n",
         "from pathlib import Path\n",

--- a/notebooks/weak/features/strong_lensing/a2744.ipynb
+++ b/notebooks/weak/features/strong_lensing/a2744.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/weak/features/strong_lensing/fit.ipynb
+++ b/notebooks/weak/features/strong_lensing/fit.ipynb
@@ -70,7 +70,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/weak/features/strong_lensing/modeling.ipynb
+++ b/notebooks/weak/features/strong_lensing/modeling.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/weak/features/strong_lensing/simulator.ipynb
+++ b/notebooks/weak/features/strong_lensing/simulator.ipynb
@@ -80,7 +80,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/weak/fit.ipynb
+++ b/notebooks/weak/fit.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/weak/likelihood_function.ipynb
+++ b/notebooks/weak/likelihood_function.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",

--- a/notebooks/weak/modeling.ipynb
+++ b/notebooks/weak/modeling.ipynb
@@ -96,7 +96,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/weak/plot.ipynb
+++ b/notebooks/weak/plot.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "import autolens as al\n",

--- a/notebooks/weak/real_data/a2744.ipynb
+++ b/notebooks/weak/real_data/a2744.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/weak/simulator.ipynb
+++ b/notebooks/weak/simulator.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
     "\n",
-    "# from autolens import setup_notebook; setup_notebook()\n",
+    "from autolens import setup_notebook; setup_notebook()\n",
     "\n",
     "from pathlib import Path\n",
     "\n",

--- a/notebooks/weak/start_here.ipynb
+++ b/notebooks/weak/start_here.ipynb
@@ -109,7 +109,7 @@
       "source": [
         "from autolens import jax_wrapper  # Sets JAX environment before other imports\n",
         "\n",
-        "# from autolens import setup_notebook; setup_notebook()\n",
+        "from autolens import setup_notebook; setup_notebook()\n",
         "\n",
         "import numpy as np\n",
         "from pathlib import Path\n",


### PR DESCRIPTION
## Summary

Wholesale notebook regeneration via PyAutoHands, clearing the sweep debt recorded in #475: since PyAutoHands `596967e` (merged 2026-08-06) the generator uncomments `from autolens import setup_notebook; setup_notebook()` in every generated notebook, but the notebooks predating that fix carried the commented (inactive) form — which is what broke notebook execution from a notebook-dir cwd and motivated the PyAutoHands fix.

## Changes

- **285 notebooks** — the `setup_notebook` line activated (one line per notebook; two notebooks carry it twice).
- **2 notebooks** (`imaging/start_here.ipynb`, `multi_galaxy/start_here.ipynb`) — additionally, JSON-indent normalization of one previously hand-edited line (`batch_size=None, …`) back to canonical `json.dump` output.
- **No scripts touched**; navigator catalogue (`llms-full.txt` / `workspace_index.json`) regenerated identical; markdown untouched.

Diff verified mechanically: apart from the two indent-normalized lines, every changed line contains `setup_notebook`.

Companion PR: autofit_workspace (same sweep, 29 notebooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGua3k2WDPVrtvj4MTMUoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGua3k2WDPVrtvj4MTMUoT)_