### PR TITLE
fix: replace hardcoded sample indexes with final-sample / clamped access

### DIFF
--- a/scripts/guides/results/aggregator/galaxies_fits.py
+++ b/scripts/guides/results/aggregator/galaxies_fits.py
@@ -174,11 +174,13 @@ __Refitting__
 Using the API introduced in the first tutorial, we can also refit the data locally. 
 
 This allows us to inspect how the tracer changes for models with similar log likelihoods. We create and plot
-the tracer of the tenth-last accepted model by Nautilus.
+the tracer of the tenth-last accepted model by Nautilus (clamped to the oldest stored sample when fewer are
+available).
 """
 samples = result.samples
 
-instance = samples.from_sample_index(sample_index=-10)
+sample_index = max(-10, -len(samples.parameter_lists))
+instance = samples.from_sample_index(sample_index=sample_index)
 
 # Input to FitImaging to solve for linear light profile intensities, see `start_here.py` for details.
 tracer = al.Tracer(galaxies=instance.galaxies)
@@ -236,11 +238,13 @@ __Refitting__
 Using the API introduced in the first tutorial, we can also refit the data locally. 
 
 This allows us to inspect how the fit changes for models with similar log likelihoods. Below, we refit and plot
-the fit of the tenth-last accepted model by Nautilus.
+the fit of the tenth-last accepted model by Nautilus (clamped to the oldest stored sample when fewer are
+available).
 """
 samples = result.samples
 
-instance = samples.from_sample_index(sample_index=-10)
+sample_index = max(-10, -len(samples.parameter_lists))
+instance = samples.from_sample_index(sample_index=sample_index)
 
 tracer = al.Tracer(galaxies=instance.galaxies)
 

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -196,8 +196,8 @@ The parameters are stored as a list of lists, where:
 """
 print("All parameters of the very first sample")
 print(samples.parameter_lists[0])
-print("The fourth parameter of the tenth sample")
-print(samples.parameter_lists[9][3])
+print("The fourth parameter of the final sample")
+print(samples.parameter_lists[-1][3])
 
 """
 __Figures of Merit__
@@ -213,13 +213,13 @@ The `Samples` class contains the log likelihood, log prior, log posterior and we
 - The `weight` gives information on how samples are combined to estimate the posterior, which depends on type of search
   used (for `Nautilus` they are all non-zero values which sum to 1).
 
-Lets inspect these values for the tenth sample.
+Lets inspect these values for the final sample.
 """
-print("log(likelihood), log(prior), log(posterior) and weight of the tenth sample.")
-print(samples.log_likelihood_list[9])
-print(samples.log_prior_list[9])
-print(samples.log_posterior_list[9])
-print(samples.weight_list[9])
+print("log(likelihood), log(prior), log(posterior) and weight of the final sample.")
+print(samples.log_likelihood_list[-1])
+print(samples.log_prior_list[-1])
+print(samples.log_posterior_list[-1])
+print(samples.weight_list[-1])
 
 """
 __Instances__

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -142,8 +142,8 @@ The parameters are stored as a list of lists, where:
 for samples in agg.values("samples"):
     print("All parameters of the very first sample")
     print(samples.parameter_lists[0])
-    print("The third parameter of the tenth sample")
-    print(samples.parameter_lists[9][2])
+    print("The third parameter of the final sample")
+    print(samples.parameter_lists[-1][2])
     print()
 
 """
@@ -171,14 +171,14 @@ The `Samples` class contains the log likelihood, log prior, log posterior and we
 - The `weight` gives information on how samples are combined to estimate the posterior, which depends on type of search
   used (for `Nautilus` they are all non-zero values which sum to 1).
 
-Lets inspect these values for the tenth sample of each of the 3 model-fits.
+Lets inspect these values for the final sample of each of the 3 model-fits.
 """
 for samples in agg.values("samples"):
-    print("log(likelihood), log(prior), log(posterior) and weight of the tenth sample.")
-    print(samples.log_likelihood_list[9])
-    print(samples.log_prior_list[9])
-    print(samples.log_posterior_list[9])
-    print(samples.weight_list[9])
+    print("log(likelihood), log(prior), log(posterior) and weight of the final sample.")
+    print(samples.log_likelihood_list[-1])
+    print(samples.log_prior_list[-1])
+    print(samples.log_posterior_list[-1])
+    print(samples.weight_list[-1])
 
 """
 __Samples Summary__

--- a/scripts/guides/results/database/start_here.py
+++ b/scripts/guides/results/database/start_here.py
@@ -369,8 +369,8 @@ sampled using the fit or an instance of the maximum likelihood model.
 The `Samples` class is described fully in the results cookbook.
 """
 for samples in agg.values("samples"):
-    print("The tenth sample`s third parameter")
-    print(samples.parameter_lists[9][2], "\n")
+    print("The final sample`s third parameter")
+    print(samples.parameter_lists[-1][2], "\n")
 
 """
 Therefore, by loading the `Samples` via the database we can now access the results of the fit to each dataset.


### PR DESCRIPTION
## Summary
Part of PyAutoLabs/autofit_workspace#140 (one PR per affected repo). Four guides hardcoded stored-sample indexes that raise `IndexError` for runs with fewer than 10 samples (e.g. `PYAUTO_TEST_MODE` sweeps): `parameter_lists[9][k]` and the `log_likelihood/log_prior/log_posterior/weight_list[9]` figure-of-merit prints, plus `from_sample_index(sample_index=-10)` in `galaxies_fits.py`. The `[9]` sites unify to the final sample via `[-1]` with matching prose; the `-10` sites (which deliberately show a near-best model) are clamped with `max(-10, -len(samples.parameter_lists))` so the teaching intent survives while never indexing out of range.

## Scripts Changed
- `scripts/guides/results/database/start_here.py` — `[9]` → `[-1]`
- `scripts/guides/results/aggregator/samples.py` — `[9]` × 5 → `[-1]`
- `scripts/guides/results/aggregator/samples_via_aggregator.py` — `[9]` × 5 → `[-1]`
- `scripts/guides/results/aggregator/galaxies_fits.py` — two `from_sample_index(-10)` calls clamped; prose notes the clamp
Notebook twins left to release-time regeneration.

## Test Plan
- [x] All four scripts run under their CI env profiles (`ENV: real_search` honored) via the workspace runner — 4/4 PASS

Generated by the PyAutoLabs agent workflow.