### PR TITLE
chore: regenerate notebook twins for the #140 script changes

### DIFF
--- a/notebooks/guides/results/aggregator/galaxies_fits.ipynb
+++ b/notebooks/guides/results/aggregator/galaxies_fits.ipynb
@@ -271,7 +271,8 @@
     "Using the API introduced in the first tutorial, we can also refit the data locally. \n",
     "\n",
     "This allows us to inspect how the tracer changes for models with similar log likelihoods. We create and plot\n",
-    "the tracer of the tenth-last accepted model by Nautilus."
+    "the tracer of the tenth-last accepted model by Nautilus (clamped to the oldest stored sample when fewer are\n",
+    "available)."
    ]
   },
   {
@@ -280,7 +281,8 @@
    "source": [
     "samples = result.samples\n",
     "\n",
-    "instance = samples.from_sample_index(sample_index=-10)\n",
+    "sample_index = max(-10, -len(samples.parameter_lists))\n",
+    "instance = samples.from_sample_index(sample_index=sample_index)\n",
     "\n",
     "# Input to FitImaging to solve for linear light profile intensities, see `start_here.py` for details.\n",
     "tracer = al.Tracer(galaxies=instance.galaxies)\n",
@@ -376,7 +378,8 @@
     "Using the API introduced in the first tutorial, we can also refit the data locally. \n",
     "\n",
     "This allows us to inspect how the fit changes for models with similar log likelihoods. Below, we refit and plot\n",
-    "the fit of the tenth-last accepted model by Nautilus."
+    "the fit of the tenth-last accepted model by Nautilus (clamped to the oldest stored sample when fewer are\n",
+    "available)."
    ]
   },
   {
@@ -385,7 +388,8 @@
    "source": [
     "samples = result.samples\n",
     "\n",
-    "instance = samples.from_sample_index(sample_index=-10)\n",
+    "sample_index = max(-10, -len(samples.parameter_lists))\n",
+    "instance = samples.from_sample_index(sample_index=sample_index)\n",
     "\n",
     "tracer = al.Tracer(galaxies=instance.galaxies)\n",
     "\n",

--- a/notebooks/guides/results/aggregator/samples.ipynb
+++ b/notebooks/guides/results/aggregator/samples.ipynb
@@ -321,8 +321,8 @@
    "source": [
     "print(\"All parameters of the very first sample\")\n",
     "print(samples.parameter_lists[0])\n",
-    "print(\"The fourth parameter of the tenth sample\")\n",
-    "print(samples.parameter_lists[9][3])"
+    "print(\"The fourth parameter of the final sample\")\n",
+    "print(samples.parameter_lists[-1][3])"
    ],
    "outputs": [],
    "execution_count": null
@@ -344,18 +344,18 @@
     "- The `weight` gives information on how samples are combined to estimate the posterior, which depends on type of search\n",
     "  used (for `Nautilus` they are all non-zero values which sum to 1).\n",
     "\n",
-    "Lets inspect these values for the tenth sample."
+    "Lets inspect these values for the final sample."
    ]
   },
   {
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "print(\"log(likelihood), log(prior), log(posterior) and weight of the tenth sample.\")\n",
-    "print(samples.log_likelihood_list[9])\n",
-    "print(samples.log_prior_list[9])\n",
-    "print(samples.log_posterior_list[9])\n",
-    "print(samples.weight_list[9])"
+    "print(\"log(likelihood), log(prior), log(posterior) and weight of the final sample.\")\n",
+    "print(samples.log_likelihood_list[-1])\n",
+    "print(samples.log_prior_list[-1])\n",
+    "print(samples.log_posterior_list[-1])\n",
+    "print(samples.weight_list[-1])"
    ],
    "outputs": [],
    "execution_count": null

--- a/notebooks/guides/results/aggregator/samples_via_aggregator.ipynb
+++ b/notebooks/guides/results/aggregator/samples_via_aggregator.ipynb
@@ -234,8 +234,8 @@
     "for samples in agg.values(\"samples\"):\n",
     "    print(\"All parameters of the very first sample\")\n",
     "    print(samples.parameter_lists[0])\n",
-    "    print(\"The third parameter of the tenth sample\")\n",
-    "    print(samples.parameter_lists[9][2])\n",
+    "    print(\"The third parameter of the final sample\")\n",
+    "    print(samples.parameter_lists[-1][2])\n",
     "    print()"
    ],
    "outputs": [],
@@ -280,7 +280,7 @@
     "- The `weight` gives information on how samples are combined to estimate the posterior, which depends on type of search\n",
     "  used (for `Nautilus` they are all non-zero values which sum to 1).\n",
     "\n",
-    "Lets inspect these values for the tenth sample of each of the 3 model-fits."
+    "Lets inspect these values for the final sample of each of the 3 model-fits."
    ]
   },
   {
@@ -288,11 +288,11 @@
    "metadata": {},
    "source": [
     "for samples in agg.values(\"samples\"):\n",
-    "    print(\"log(likelihood), log(prior), log(posterior) and weight of the tenth sample.\")\n",
-    "    print(samples.log_likelihood_list[9])\n",
-    "    print(samples.log_prior_list[9])\n",
-    "    print(samples.log_posterior_list[9])\n",
-    "    print(samples.weight_list[9])"
+    "    print(\"log(likelihood), log(prior), log(posterior) and weight of the final sample.\")\n",
+    "    print(samples.log_likelihood_list[-1])\n",
+    "    print(samples.log_prior_list[-1])\n",
+    "    print(samples.log_posterior_list[-1])\n",
+    "    print(samples.weight_list[-1])"
    ],
    "outputs": [],
    "execution_count": null

--- a/notebooks/guides/results/database/start_here.ipynb
+++ b/notebooks/guides/results/database/start_here.ipynb
@@ -537,8 +537,8 @@
    "metadata": {},
    "source": [
     "for samples in agg.values(\"samples\"):\n",
-    "    print(\"The tenth sample`s third parameter\")\n",
-    "    print(samples.parameter_lists[9][2], \"\\n\")"
+    "    print(\"The final sample`s third parameter\")\n",
+    "    print(samples.parameter_lists[-1][2], \"\\n\")"
    ],
    "outputs": [],
    "execution_count": null


### PR DESCRIPTION
## Summary
Follow-up to #487 (merged): regenerates the notebook twins of the four scripts touched by PyAutoLabs/autofit_workspace#140 via PyAutoHands `generate.py`, per this workspace's convention. One unrelated pre-existing notebook drift (`aggregator/interferometer.ipynb`) was deliberately left out.

## Test Plan
- [x] `generate.py autolens` reported 352 scripts; committed diff confined to the four intended notebooks.

Generated by the PyAutoLabs agent workflow.