### PR TITLE
maintenance: raw-string the LaTeX-carrying docstrings

### DIFF
--- a/scripts/group/features/linear_light_profiles/likelihood_function.py
+++ b/scripts/group/features/linear_light_profiles/likelihood_function.py
@@ -245,7 +245,7 @@ print(fit_figure_of_merit)
 
 aplt.subplot_fit_imaging(fit=fit)
 
-"""
+r"""
 __Likelihood Function__
 
 The likelihood function for linear light profiles includes the same terms as the standard parametric case:

--- a/scripts/group/features/multi_gaussian_expansion/likelihood_function.py
+++ b/scripts/group/features/multi_gaussian_expansion/likelihood_function.py
@@ -261,7 +261,7 @@ convolved_image_2d = masked_dataset.psf.convolved_image_from(
 
 aplt.plot_array(array=convolved_image_2d, title="Convolved Image")
 
-"""
+r"""
 __Likelihood Function__
 
 We now quantify the goodness-of-fit of our group-scale lens model.

--- a/scripts/group/likelihood_function.py
+++ b/scripts/group/likelihood_function.py
@@ -154,7 +154,7 @@ print(
     f"(y,x) coordinates of first ten unmasked image-pixels {masked_dataset.grid[0:9]}"
 )
 
-"""
+r"""
 __Lens Galaxy Light (Setup)__
 
 To perform a likelihood evaluation we now compose our lens model.
@@ -388,7 +388,7 @@ convolved_image_2d = masked_dataset.psf.convolved_image_from(
 
 aplt.plot_array(array=convolved_image_2d, title="Convolved Image")
 
-"""
+r"""
 __Likelihood Function__
 
 We now quantify the goodness-of-fit of our group-scale lens model.

--- a/scripts/guides/galaxies.py
+++ b/scripts/guides/galaxies.py
@@ -197,7 +197,7 @@ The `aplt.plot_array` makes it straight forward to extract and plot an individua
 """
 aplt.plot_array(array=tracer.image_2d_from(grid=grid), title="Image")
 
-"""
+r"""
 __Log10__
 
 The light distributions of galaxies are closer to a log10 distribution than a linear one. 

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -147,7 +147,7 @@ for fit_list in fit_gen:
 
     aplt.subplot_fit_imaging(fit=fit)
 
-"""
+r"""
 __Visualization Customization__
 
 The benefit of inspecting fits using the aggregator, rather than the files outputs to the hard-disk, is that we can 

--- a/scripts/guides/tracer.py
+++ b/scripts/guides/tracer.py
@@ -214,7 +214,7 @@ aplt.plot_array(
     array=tracer.image_2d_from(grid=grid), title="Image of Strong Lens System"
 )
 
-"""
+r"""
 __Log10__
 
 The light and masss distributions of galaxies are closer to a log10 distribution than a linear one. 

--- a/scripts/imaging/features/advanced/potential_correction/likelihood_function.py
+++ b/scripts/imaging/features/advanced/potential_correction/likelihood_function.py
@@ -1,4 +1,4 @@
-"""
+r"""
 __Log Likelihood Function: Potential Correction (Gravitational Imaging)__
 
 This script provides a step-by-step guide of the **PyAutoLens** potential-correction `log_likelihood_function`
@@ -70,7 +70,7 @@ from scipy.sparse import block_diag
 import autolens as al
 import autolens.plot as aplt
 
-"""
+r"""
 __Dataset__
 
 We simulate the dataset in-memory (seeded, so this script is fully reproducible): an `IsothermalSph` lens whose
@@ -104,7 +104,7 @@ dataset = simulator.via_tracer_from(
     tracer=al.Tracer(galaxies=[lens_true, source_true]), grid=grid
 )
 
-"""
+r"""
 __Arc Mask__
 
 The corrections respond to the data only through the source's brightness gradients, which vanish away from the
@@ -124,7 +124,7 @@ masked_imaging = dataset.apply_mask(mask=mask)
 n_data = int(np.count_nonzero(~mask_array))
 print(f"unmasked data pixels: n_data = {n_data}")
 
-"""
+r"""
 __Smooth Starting Model__
 
 Potential corrections perturb a smooth starting model — in a real analysis, the maximum-likelihood result of a
@@ -136,7 +136,7 @@ gradients $(\partial S / \partial y, \partial S / \partial x)$ at arbitrary sour
 lens_smooth = al.Galaxy(redshift=0.2, mass=lens_true.mass)
 source_start = al.pc.AnalyticSrcFactory(source_galaxy=source_true)
 
-"""
+r"""
 __Dpsi Mesh__
 
 The corrections are defined on a rectangular mesh a factor coarser than the data grid (here factor 2).
@@ -160,7 +160,7 @@ print(
     f"itp_mat shape = {pair.itp_mat.shape}, row sums all 1: {np.allclose(pair.itp_mat.sum(axis=1), 1.0)}"
 )
 
-"""
+r"""
 __Dpsi Gradient Operator__
 
 The correction $\delta\psi$ deflects rays by its gradient: $\delta\alpha = \nabla \delta\psi$. The sparse operator
@@ -175,7 +175,7 @@ dpsi_gradient_matrix = al.pc.util.dpsi_gradient_matrix_from(
 )
 print(f"D_psi shape = {dpsi_gradient_matrix.shape}")
 
-"""
+r"""
 __Source Gradients__
 
 A small extra deflection $\delta\alpha$ at an image pixel re-samples the source at a position shifted
@@ -207,7 +207,7 @@ psf_matrix = al.pc.util.psf_matrix_from(
 )
 print(f"B shape = {psf_matrix.shape}")
 
-"""
+r"""
 __Dpsi Mapping Matrix__
 
 Combining the three operators gives the linear response of the observed image to the mesh corrections
@@ -222,7 +222,7 @@ dpsi_mapping_matrix = np.asarray(
 )
 print(f"dpsi mapping matrix shape = {dpsi_mapping_matrix.shape}")
 
-"""
+r"""
 __Source Inversion Blocks__
 
 The joint inversion reconstructs the source simultaneously. Its source blocks come from the standard pixelized
@@ -248,7 +248,7 @@ src_regularization_matrix = np.asarray(src_fit.inversion.regularization_matrix)
 n_src = src_regularization_matrix.shape[0]
 print(f"F_src shape = {src_mapping_matrix.shape}, n_src = {n_src}")
 
-"""
+r"""
 __Joint System__
 
 The joint linear system stacks the two blocks:
@@ -274,7 +274,7 @@ regularization_matrix = np.asarray(
 )
 print(f"joint mapping matrix shape = {mapping_matrix.shape}")
 
-"""
+r"""
 __Solve__
 
 With diagonal noise covariance $C^{-1} = \rm{diag}(1/\sigma_i^2)$, the maximum-evidence solution of the joint
@@ -298,7 +298,7 @@ source_solution = solution[:n_src]
 dpsi_solution = solution[n_src:]
 model_image = mapping_matrix @ solution
 
-"""
+r"""
 __Dkappa Map__
 
 The corrections' physical meaning is clearest as a convergence correction,
@@ -325,7 +325,7 @@ plt.tight_layout()
 plt.show()
 plt.close()
 
-"""
+r"""
 __Evidence Terms__
 
 The Bayesian evidence of the joint inversion has five terms (Suyu et al. 2006 eq. 19; Cao et al. 2025):

--- a/scripts/imaging/features/advanced/potential_correction/start_here.py
+++ b/scripts/imaging/features/advanced/potential_correction/start_here.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Potential Correction: Start Here
 ================================
 
@@ -68,7 +68,7 @@ import autofit as af
 import autolens as al
 import autolens.plot as aplt
 
-"""
+r"""
 __Simulate__
 
 We simulate imaging of a strong lens whose mass model is an `Isothermal` plus a $10^{10} \, M_\odot$ NFW dark
@@ -198,7 +198,7 @@ fit = al.pc.FitDpsiSrcImaging(
 
 print(f"joint source + dpsi log evidence = {fit.log_evidence:.4e}")
 
-"""
+r"""
 __Dkappa Map__
 
 The reconstructed corrections live on the coarse dpsi mesh (`fit.best_fit_dpsi`). Their physical meaning is clearest
@@ -224,7 +224,7 @@ al.pc.visualize.show_fit_dpsi_src(
     fit, output=path.join("output", "potential_correction_joint_fit.png")
 )
 
-"""
+r"""
 __Iterative Fit__
 
 The joint fit above linearizes the corrections around the smooth model once. The iterative engine
@@ -261,7 +261,7 @@ print(
     f"{iter_fit.pair_dpsi_data_obj.xgrid_dpsi_1d[peak]:.2f})"
 )
 
-"""
+r"""
 __Evidence Sampling__
 
 In a real analysis the regularization hyper-parameters (the coefficients and scales above) are not known. They are

--- a/scripts/imaging/features/linear_light_profiles/likelihood_function.py
+++ b/scripts/imaging/features/linear_light_profiles/likelihood_function.py
@@ -1,4 +1,4 @@
-"""
+r"""
 __Log Likelihood Function: Linear Light Profile__
 
 This script provides a step-by-step guide of the `log_likelihood_function` which is used to fit `Imaging` data with
@@ -389,7 +389,7 @@ print(
     f"Mapping between image pixel 0 and linear light profile pixel 1 = {mapping_matrix[0, 1]}"
 )
 
-"""
+r"""
 __Data Vector (D)__
 
 To solve for the linear light profile intensities we now pose the problem as a linear inversion.
@@ -443,7 +443,7 @@ print("Data Vector:")
 print(data_vector)
 print(data_vector.shape)
 
-"""
+r"""
 __Curvature Matrix (F)__
 
 The `curvature_matrix` $F$ is the second matrix and it has 
@@ -475,7 +475,7 @@ plt.show()
 plt.close()
 
 
-"""
+r"""
 __Reconstruction (Positive-Negative)__
 
 The following chi-squared is minimized when we perform the inversion and reconstruct the galaxy:
@@ -559,7 +559,7 @@ mapped_reconstructed_operated_data = al.Array2D(
 aplt.plot_array(array=mapped_reconstructed_operated_data, title="")
 
 
-"""
+r"""
 __Likelihood Function__
 
 We now quantify the goodness-of-fit of our galaxy model.

--- a/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
@@ -1,4 +1,4 @@
-"""
+r"""
 __Log Likelihood Function: Multi Gaussian Expansion__
 
 This script provides a step-by-step guide of the `log_likelihood_function` which is used to fit `Imaging` data with
@@ -472,7 +472,7 @@ print(
     f"Mapping between image pixel 0 and Gaussian linear light profile pixel 1 = {mapping_matrix[0, 1]}"
 )
 
-"""
+r"""
 __Data Vector (D)__
 
 To solve for the linear light profile intensities we now pose the problem as a linear inversion.
@@ -526,7 +526,7 @@ print("Data Vector:")
 print(data_vector)
 print(data_vector.shape)
 
-"""
+r"""
 __Curvature Matrix (F)__
 
 The `curvature_matrix` $F$ is the second matrix and it has 
@@ -558,7 +558,7 @@ plt.show()
 plt.close()
 
 
-"""
+r"""
 __Reconstruction (Positive-Negative)__
 
 The following chi-squared is minimized when we perform the inversion and reconstruct the galaxy:
@@ -683,7 +683,7 @@ mapped_reconstructed_operated_data = al.Array2D(
 aplt.plot_array(array=mapped_reconstructed_operated_data, title="")
 
 
-"""
+r"""
 __Likelihood Function__
 
 We now quantify the goodness-of-fit of our galaxy model.

--- a/scripts/imaging/features/pixelization/likelihood_function.py
+++ b/scripts/imaging/features/pixelization/likelihood_function.py
@@ -1,4 +1,4 @@
-"""
+r"""
 __Log Likelihood Function: Pixelization__
 
 This script provides a step-by-step guide of the **PyAutoLens** `log_likelihood_function` which is used to fit
@@ -267,7 +267,7 @@ lens_subtracted_image = masked_dataset.data - convolved_image_2d
 
 aplt.plot_array(array=lens_subtracted_image, title="")
 
-"""
+r"""
 __Ray Tracing__
 
 To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the image-plane to its (y,x) 
@@ -578,7 +578,7 @@ are the first entry of `mapping_matrix` whereas for $f$ they are the second inde
 """
 print(f"Mapping between image pixel 0 and source pixel 2 = {mapping_matrix[0, 2]}")
 
-"""
+r"""
 __Data Vector (D)__
 
 To solve for the source pixel fluxes we now pose the problem as a linear inversion.
@@ -622,7 +622,7 @@ plt.colorbar()
 plt.show()
 plt.close()
 
-"""
+r"""
 __Curvature Matrix (F)__
 
 The `curvature_matrix` $F$ is the second matrix and it has dimensions `(total_source_pixels, total_source_pixels)`.
@@ -672,7 +672,7 @@ array_2d = al.Array2D(
 
 aplt.plot_array(array=array_2d, title="")
 
-"""
+r"""
 The following chi-squared is minimized when we perform the inversion and reconstruct the source:
 
 $\chi^2 = \sum_{\rm  j=1}^{J} \bigg[ \frac{(\sum_{\rm  i=1}^{I} s_{i} f_{ij}) + b_{j} - d_{j}}{\sigma_{j}} \bigg]$
@@ -706,7 +706,7 @@ ill-posed. We need to apply some form of smoothing on the source reconstruction 
 
 aplt.plot_grid(grid=mapper.source_plane_mesh_grid, title="Source-Plane Mesh Grid")
 
-"""
+r"""
 __Regularization Matrix (H)__
 
 Regularization adds a linear regularization term $G_{\rm L}$ to the $\chi^2$ we solve for giving us a new merit 
@@ -802,7 +802,7 @@ mapped_reconstructed_operated_data = al.Array2D(
 
 aplt.plot_array(array=mapped_reconstructed_operated_data, title="")
 
-"""
+r"""
 __Likelihood Function__
 
 We now quantify the goodness-of-fit of our lens model and source reconstruction. 
@@ -851,7 +851,7 @@ chi_squared_map = al.Array2D(values=chi_squared_map, mask=mask)
 aplt.plot_array(array=chi_squared_map, title="")
 
 
-"""
+r"""
 __Regularization Term__
 
 The second term, $s^{T} H s$, corresponds to the $\lambda $G_{\rm L}$ regularization term we added to our merit 
@@ -870,7 +870,7 @@ regularization_term = np.matmul(
 
 print(regularization_term)
 
-"""
+r"""
 __Complexity Terms__
 
 Up to this point, it is unclear why we chose a value of `regularization_coefficient=1.0`. 

--- a/scripts/imaging/likelihood_function.py
+++ b/scripts/imaging/likelihood_function.py
@@ -1,4 +1,4 @@
-"""
+r"""
 __Log Likelihood Function: Inversion (Parametric)__
 
 This script provides a step-by-step guide of the `log_likelihood_function` which is used to fit `Imaging` data with
@@ -176,7 +176,7 @@ print(
     f"(y,x) coordinates of first ten unmasked image-pixels {masked_dataset.grid[0:9]}"
 )
 
-"""
+r"""
 To perform lensing calculations we convert this 2D (y,x) grid of coordinates to elliptical coordinates:
 
  $\eta = \sqrt{(x - x_c)^2 + (y - y_c)^2/q^2}$
@@ -211,7 +211,7 @@ print(
     f"transformed coordinates of first ten unmasked image-pixels {transformed_grid[0:9]}"
 )
 
-"""
+r"""
 Using these transformed (y',x') values we compute the elliptical coordinates $\eta = \sqrt{(x')^2 + (y')^2/q^2}$
 """
 elliptical_radii = profile.elliptical_radii_grid_from(grid=transformed_grid)
@@ -220,7 +220,7 @@ print(
     f"elliptical coordinates of first ten unmasked image-pixels {elliptical_radii[0:9]}"
 )
 
-"""
+r"""
 __Lens Galaxy Light (Setup)__
 
 To perform a likelihood evaluation we now compose our lens model.
@@ -260,7 +260,7 @@ image_2d_bulge = bulge.image_2d_from(grid=masked_dataset.grid)
 
 aplt.plot_array(array=bulge.image_2d_from(grid=masked_dataset.grid), title="Image")
 
-"""
+r"""
 __Lens Galaxy Mass__
 
 We next define the mass profiles which represents the lens galaxy's mass, which will be used to ray-trace the 
@@ -307,7 +307,7 @@ aplt.plot_array(
     array=mass.convergence_2d_from(grid=masked_dataset.grid), title="Convergence"
 )
 
-"""
+r"""
 From each mass profile we can compute its deflection angles, which describe how due to gravitational lensing
 image-pixels are ray-traced to the source plane.
 
@@ -374,7 +374,7 @@ actual mask whose light blurs into the image:
 lens_blurring_image_2d = lens_galaxy.image_2d_from(grid=masked_dataset.grids.blurring)
 
 
-"""
+r"""
 __Ray Tracing__
 
 To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the image-plane to its (y,x) 
@@ -444,7 +444,7 @@ convolved_image_2d = masked_dataset.psf.convolved_image_from(
 
 aplt.plot_array(array=convolved_image_2d, title="")
 
-"""
+r"""
 __Likelihood Function__
 
 We now quantify the goodness-of-fit of our lens and source model.

--- a/scripts/interferometer/features/advanced/potential_correction/likelihood_function.py
+++ b/scripts/interferometer/features/advanced/potential_correction/likelihood_function.py
@@ -1,4 +1,4 @@
-"""
+r"""
 __Log Likelihood Function: Potential Correction (Interferometer)__
 
 This script provides a step-by-step guide of the **PyAutoLens** visibility-space potential-correction
@@ -70,7 +70,7 @@ import autoarray as aa
 import autolens as al
 import autolens.plot as aplt
 
-"""
+r"""
 __Dataset__
 
 We simulate the dataset in-memory (seeded, so this script is fully reproducible): random uv coverage, an
@@ -138,7 +138,7 @@ print(
     f"visibilities: {uv_wavelengths.shape[0]}, real-space mask pixels: n_full = {n_full}"
 )
 
-"""
+r"""
 __Smooth Starting Model__
 
 Potential corrections perturb a smooth starting model — in a real analysis, the maximum-likelihood result of a
@@ -178,7 +178,7 @@ src_regularization_matrix = np.asarray(src_fit.inversion.regularization_matrix)
 n_src = src_regularization_matrix.shape[0]
 print(f"f shape = {src_mapping_matrix.shape}, n_src = {n_src}")
 
-"""
+r"""
 __Dpsi Mesh__
 
 The corrections are only constrained where the lensed arcs are, so their mesh is restricted to an arc-tracing
@@ -202,7 +202,7 @@ n_sub = int(np.count_nonzero(~pair.mask_data))
 n_dpsi = int(np.count_nonzero(~pair.mask_dpsi))
 print(f"arc pixels: n_sub = {n_sub}, dpsi mesh pixels: n_dpsi = {n_dpsi}")
 
-"""
+r"""
 __Correction Response__
 
 As in the imaging walkthrough, a correction $\delta\psi$ perturbs the observed image via the source's brightness
@@ -240,7 +240,7 @@ G = np.zeros((n_full, n_dpsi))
 G[rows_in_full] = G_sub
 print(f"G shape = {G.shape}")
 
-"""
+r"""
 __Joint Response__
 
 The joint real-space response stacks the two blocks, $A = [\, f \; | \; G \,]$, alongside the block-diagonal
@@ -288,7 +288,7 @@ curvature_matrix = M.T @ (M * stacked_inv_variance[:, None])
 data_vector = M.T @ (stacked_inv_variance * stacked_data)
 print(f"dense route: M shape = {M.shape}, curvature shape = {curvature_matrix.shape}")
 
-"""
+r"""
 __Sparse (w-tilde) Route__
 
 The production route computes the identical $F$ and $D$ without ever forming $T(A)$ (Powell et al. 2021's
@@ -308,7 +308,7 @@ print(
     f"{np.allclose(data_vector_sparse, data_vector, rtol=1e-6)}"
 )
 
-"""
+r"""
 The sparse curvature is assembled from the COO triplets of $A$ (the machinery `al.pc.FitDpsiSrcInterferometer`
 uses internally); rather than repeat that plumbing here, we take the fit's sparse-route curvature below and verify
 it against our dense $F$ at the end. For this walkthrough we continue with the dense-route matrices, which we have
@@ -327,7 +327,7 @@ solution = np.linalg.solve(curvature_reg_matrix, data_vector)
 source_solution = solution[:n_src]
 dpsi_solution = solution[n_src:]
 
-"""
+r"""
 __Dkappa Map__
 
 The corrections' physical meaning is clearest as a convergence correction,
@@ -354,7 +354,7 @@ plt.tight_layout()
 plt.show()
 plt.close()
 
-"""
+r"""
 __Evidence Terms__
 
 The Bayesian evidence of the joint inversion has five terms (Suyu et al. 2006 eq. 19; Cao et al. 2025), with the

--- a/scripts/interferometer/features/advanced/potential_correction/start_here.py
+++ b/scripts/interferometer/features/advanced/potential_correction/start_here.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Feature: Potential Correction (Gravitational Imaging)
 =====================================================
 
@@ -85,7 +85,7 @@ uv_wavelengths = synthesis_uv_from(
 )
 print(f"{uv_wavelengths.shape[0]} visibilities")
 
-"""
+r"""
 __Simulate__
 
 An `Isothermal` lens whose true mass also contains a $10^{10} M_\odot$ NFW subhalo on the Einstein ring, and a
@@ -161,7 +161,7 @@ source, isolating the technique itself. The source enters the correction operato
 lens_smooth = al.Galaxy(redshift=0.2, mass=lens_true.mass)
 source_start = al.pc.AnalyticSrcFactory(source_galaxy=source_true)
 
-"""
+r"""
 __Source Pixelization + Regime Gate__
 
 The source is reconstructed on a k-nearest-neighbor mesh distributed via an `Overlay` image-mesh. Before

--- a/scripts/interferometer/features/pixelization/likelihood_function.py
+++ b/scripts/interferometer/features/pixelization/likelihood_function.py
@@ -1,4 +1,4 @@
-"""
+r"""
 __Log Likelihood Function: Pixelization__
 
 This script provides a step-by-step guide of the **PyAutoLens** `log_likelihood_function` which is used to fit
@@ -218,7 +218,7 @@ pixelization = al.Pixelization(
 
 source_galaxy = al.Galaxy(redshift=1.0, pixelization=pixelization)
 
-"""
+r"""
 __Ray Tracing__
 
 To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the image-plane to its (y,x) 
@@ -551,7 +551,7 @@ print(
     f"Mapping between visibility 0 and RectangularUniform pixel 2 = {mapping_matrix[0, 2]}"
 )
 
-"""
+r"""
 __Data Vector (D)__
 
 To solve for the source pixel fluxes we now pose the problem as a linear inversion.
@@ -600,7 +600,7 @@ print("Data Vector:")
 print(data_vector)
 print(data_vector.shape)
 
-"""
+r"""
 __Curvature Matrix (F)__
 
 The `curvature_matrix` $F$ is the second matrix and it has 
@@ -662,7 +662,7 @@ visibilities = al.Visibilities(
 
 aplt.plot_grid(grid=visibilities.in_grid, title="")
 
-"""
+r"""
 The following chi-squared is minimized when we perform the inversion and reconstruct the source_galaxy:
 
 $\chi^2 = \sum_{\rm  j=1}^{J} \bigg[ \frac{(\sum_{\rm  i=1}^{I} s_{i} f_{ij}) - d_{j}}{\sigma_{j}} \bigg]$
@@ -697,7 +697,7 @@ ill-posed. We need to apply some form of smoothing on the reconstruction to avoi
 
 aplt.plot_grid(grid=mapper.source_plane_mesh_grid, title="Source-Plane Mesh Grid")
 
-"""
+r"""
 __Regularization Matrix (H)__
 
 Regularization adds a linear regularization term $G_{\rm L}$ to the $\chi^2$ we solve for giving us a new merit 
@@ -797,7 +797,7 @@ mapped_reconstructed_visibilities = al.Visibilities(
 aplt.plot_grid(grid=mapped_reconstructed_visibilities.in_grid, title="")
 
 
-"""
+r"""
 __Likelihood Function__
 
 We now quantify the goodness-of-fit of our pixelization source galaxy reconstruction. 
@@ -862,7 +862,7 @@ chi_squared_map = al.Visibilities(visibilities=chi_squared_map)
 
 aplt.plot_grid(grid=chi_squared_map.in_grid, title="")
 
-"""
+r"""
 __Regularization Term__
 
 The second term, $s^{T} H s$, corresponds to the $\lambda $G_{\rm L}$ regularization term we added to our merit 
@@ -881,7 +881,7 @@ regularization_term = np.matmul(
 
 print(regularization_term)
 
-"""
+r"""
 __Complexity Terms__
 
 Up to this point, it is unclear why we chose a value of `regularization_coefficient=1.0`. 

--- a/scripts/interferometer/likelihood_function.py
+++ b/scripts/interferometer/likelihood_function.py
@@ -1,4 +1,4 @@
-"""
+r"""
 __Log Likelihood Function: Parametric__
 
 This script provides a step-by-step guide of the `log_likelihood_function` which is used to fit `Interferometer` data
@@ -146,7 +146,7 @@ aplt.plot_grid(grid=dataset.grids.lp, title="")
 
 print(f"(y,x) coordinates of first ten unmasked image-pixels {dataset.grid[0:9]}")
 
-"""
+r"""
 To perform lensing calculations we convert this 2D (y,x) grid of coordinates to elliptical coordinates:
 
  $\eta = \sqrt{(x - x_c)^2 + (y - y_c)^2/q^2}$
@@ -181,7 +181,7 @@ print(
     f"transformed coordinates of first ten unmasked image-pixels {transformed_grid[0:9]}"
 )
 
-"""
+r"""
 Using these transformed (y',x') values we compute the elliptical coordinates $\eta = \sqrt{(x')^2 + (y')^2/q^2}$
 """
 elliptical_radii = profile.elliptical_radii_grid_from(grid=transformed_grid)
@@ -190,7 +190,7 @@ print(
     f"elliptical coordinates of first ten unmasked image-pixels {elliptical_radii[0:9]}"
 )
 
-"""
+r"""
 __Light Profiles (Setup)__
 
 To perform a likelihood evaluation we now compose our lens model.
@@ -233,7 +233,7 @@ image_2d_bulge = bulge.image_2d_from(grid=dataset.grid)
 
 aplt.plot_array(array=bulge.image_2d_from(grid=dataset.grid), title="Image")
 
-"""
+r"""
 __Lens Galaxy Mass__
 
 We next define the mass profiles which represents the lens galaxy's mass, which will be used to ray-trace the 
@@ -278,7 +278,7 @@ shear = al.mp.ExternalShear(gamma_1=0.05, gamma_2=0.05)
 
 aplt.plot_array(array=mass.convergence_2d_from(grid=dataset.grid), title="Convergence")
 
-"""
+r"""
 From each mass profile we can compute its deflection angles, which describe how due to gravitational lensing
 image-pixels are ray-traced to the source plane.
 
@@ -335,7 +335,7 @@ This computes the `lens_image_2d` of each `LightProfile` and adds them together.
 lens_image_2d = lens_galaxy.image_2d_from(grid=dataset.grid)
 
 
-"""
+r"""
 __Ray Tracing__
 
 To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the image-plane to its (y,x) 
@@ -407,7 +407,7 @@ fully understand how this likelihood function works.
 aplt.plot_grid(grid=visibilities.in_grid, title="")
 
 
-"""
+r"""
 __Likelihood Function__
 
 We now quantify the goodness-of-fit of our galaxy model.

--- a/scripts/point_source/fit.py
+++ b/scripts/point_source/fit.py
@@ -186,7 +186,7 @@ multiple images coincide with the centers of the brightest pixels of the lensed 
 
 aplt.plot_array(array=tracer_extended.image_2d_from(grid=grid), title="Image")
 
-"""
+r"""
 __Number of Solutions__
 
 The number of solutions (e.g. the number of image-plane multiple images that map to the source centre) depends


### PR DESCRIPTION
Part of #491 — the largest of six independent, prose-only PRs (one per workspace repo). No API surface, so no cross-repo merge ordering.

Non-raw docstrings containing LaTeX are corrupted by Python's escape handling, in two classes — and only one of them is visible:

| | what it is | diagnostic |
|---|---|---|
| **warned** | `\s`, `\l`, `\[` — escapes Python does *not* recognise | `SyntaxWarning` per compile; slated to become `SyntaxError` |
| **silent** | `\t` in `\theta`, `\f` in `\frac`, `\r` in `\rm` | **none at all** — the value is simply corrupted |

**83 literals across 17 files** get the `r` prefix. The 17 files and 80 warnings match the independent 2026-08-09 measurement exactly. Prose is untouched — only the delimiter gains an `r`.

## Verification

- **Baseline regeneration is a no-op** — the generator was run *before* editing and left the tree clean, so generator noise cannot fake the gate below.
- **Runtime values**: 61 corruptions repaired, **0 other changes**. Every changed literal's value was compared HEAD vs worktree; the prefix may only ever *remove* corruption. This is the check that catches real mistakes — the regeneration gate structurally cannot, because the generator reads source text, not runtime values.
- **Regenerated with autohands**: `notebooks/`, `markdown/`, `llms-full.txt` and `workspace_index.json` are **all byte-identical** — the diff-empty gate passes exactly.
- **All 57 `__Env__` declarations** in this repo re-read identically through `read_env_declaration`, byte-compared before and after.

That last check is the one that matters here. Four of the raw-stringed files carry `__Env__`:

```
scripts/imaging/features/advanced/potential_correction/likelihood_function.py
scripts/imaging/features/advanced/potential_correction/start_here.py
scripts/interferometer/features/advanced/potential_correction/likelihood_function.py
scripts/interferometer/features/advanced/potential_correction/start_here.py
```

Before PyAutoHands#251, an `r"""` opener made `read_env_declaration` return `None` — silently — which would have rerouted these scripts' smoke env profile with no error anywhere. These four files exercise that fix end to end.

## Known residue

`scripts/group/likelihood_function.py` keeps **2 warnings + 1 silent hit**. Three of its docstrings use the **double-backslash** convention (`$\\theta$`, `\\frac`, `\\vec`) mixed with a few single-backslash macros. Adding `r` would double the already-correct escapes and change the rendered LaTeX; fixing it properly means un-doubling 18 backslashes, which is a prose edit this task explicitly excludes. It needs a decision on which convention the file should use — worth a follow-up rather than a guess here. The unambiguous literals in that file were still fixed (4 warned → 2, 3 silent → 1).

Also left alone: already-escaped `\\` anywhere, real newlines in `print()`, and `dataset/cluster/a2744/prep.py:38` where `line.split("\t")` is a genuine TSV tab.

The prefix was applied only where **every** backslash in the literal sits in a LaTeX context (`$…$`, `\(…\)`, `\[…\]`, `\begin{}…\end{}`, or a markdown code span), with an absolute veto on `\\`, escaped quotes and numeric escapes regardless of context. Four docstrings with unbalanced or malformed delimiters were read in full and prefixed by hand; their delimiters were left exactly as found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTjtx5mdituitiyQYFGn2E

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTjtx5mdituitiyQYFGn2E)_