### PR TITLE
Rectangular mesh split: Bilinear default (imaging), RTU advanced — workspace leg

### DIFF
--- a/scripts/imaging/features/pixelization/likelihood_function.py
+++ b/scripts/imaging/features/pixelization/likelihood_function.py
@@ -331,7 +331,7 @@ We do this by overlying a rectangular grid on the relocated traced image-plane g
 This distributes the rectangular mesh so it fully overlaps the region of the source-plane containing the traced 
 image-pixels without having edge pixels that extend beyond this region.
 """
-from autoarray.inversion.mesh.mesh.rectangular_adapt_density import overlay_grid_from
+from autoarray.inversion.mesh.mesh.rectangular_rtu_adapt_density import overlay_grid_from
 
 mesh_grid = overlay_grid_from(
     shape_native=mesh_shape, grid=al.Grid2DIrregular(relocated_grid)

--- a/scripts/imaging/features/pixelization/modeling.py
+++ b/scripts/imaging/features/pixelization/modeling.py
@@ -124,15 +124,9 @@ size of source pixels to the density of traced points via the empirical rank CDF
 conceptually simple transform (a sort and a cumulative sum) with no extra parameters, which is why it is also
 the fastest rectangular mesh on CPUs.
 
-An advanced alternative is the `RectangularRTUAdaptDensity` mesh (and its `RectangularRTUAdaptImage`
-counterpart), which instead uses a smooth kernel-density CDF — the ray-guided transformed uniform (RTU) grid
-formulation of Enzi et al. (2026), https://arxiv.org/abs/2606.30620, which should be cited when using those
-meshes. Note the paper pairs the RTU grid with a Gaussian-process source prior, whereas these examples use
-PyAutoLens's own regularization schemes (`reg.Constant` / `reg.Adapt`). The RTU meshes are recommended on GPUs
-(where their kernel evaluation is not a bottleneck) and for gradient-based (JAX) samplers: the Bilinear mesh's
-likelihood is exactly piecewise-constant in the mass model at the default `over_sample_size_pixelization=1`
-(zero gradients), so gradient users must either set `over_sample_size_pixelization >= 4` or use the RTU meshes,
-and interferometer gradient fitting must use the RTU meshes (interferometer datasets have no over-sampling).
+An advanced alternative, the ray-guided transformed uniform (RTU) meshes, exists for GPU users and
+gradient-based (JAX) fitting — see the `__Advanced: RTU Rectangular Meshes__` section at the end of this
+script for what they are, when to use them and how to compose a model with them.
 
 __Start Here Notebook__
 
@@ -563,4 +557,43 @@ in having a go at adding them contact me on SLACK! :)
 - More diagnostic quantities for reconstructed galaxy light.
 - Gradient calculations of the reconstructed light distribution.
 - Quantifying spatial variations in galaxy structure across the image.
+"""
+
+"""
+__Advanced: RTU Rectangular Meshes__
+
+The model fitted in this example uses the default `RectangularBilinearAdaptDensity` mesh (with
+`RectangularBilinearAdaptImage` its adapt-image counterpart), which is the right choice for the vast majority
+of users: its empirical rank-CDF transform has no extra parameters and is the fastest rectangular mesh on CPUs.
+
+An advanced alternative is the ray-guided transformed uniform (RTU) mesh family, `RectangularRTUAdaptDensity`
+and `RectangularRTUAdaptImage`, which warp the source-pixel grid via a smooth kernel-density CDF instead of
+the rank CDF — the RTU grid formulation of Enzi et al. (2026), https://arxiv.org/abs/2606.30620, which should
+be cited when using these meshes.
+
+Two properties distinguish the RTU meshes:
+
+- **Fast on GPUs only**: their kernel-CDF evaluation is a bottleneck on CPUs, so CPU users should stay with
+  the Bilinear default; on GPUs the kernel evaluation is not a bottleneck and the RTU meshes run fast.
+
+- **May have smoother gradients**: the kernel CDF is smooth in the mass-model parameters, whereas the
+  Bilinear rank CDF is piecewise-constant at the default `over_sample_size_pixelization=1` (zero gradients),
+  so gradient-based (JAX) samplers may benefit from the RTU meshes. Imaging users can alternatively set
+  `over_sample_size_pixelization >= 4`; interferometer gradient fitting requires the RTU meshes, as
+  interferometer datasets have no over-sampling.
+
+Composing an RTU model is identical to the fit performed in this example, swapping only the mesh — shown as
+code below but not run here, because the full model-fit would repeat everything above:
+
+    mesh = af.Model(al.mesh.RectangularRTUAdaptDensity, shape=mesh_shape)
+    regularization = af.Model(al.reg.Constant)
+
+    pixelization = af.Model(al.Pixelization, mesh=mesh, regularization=regularization)
+
+    source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+    model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+Note the Enzi et al. paper pairs the RTU grid with a Gaussian-process source prior, whereas these examples use
+PyAutoLens's own regularization schemes (`reg.Constant` / `reg.Adapt`).
 """

--- a/scripts/interferometer/features/datacube/likelihood_function.py
+++ b/scripts/interferometer/features/datacube/likelihood_function.py
@@ -273,7 +273,7 @@ Identical to `pixelization/likelihood_function.py:__Source Pixel Centre Calculat
 overlays the relocated traced grid; since the relocated grid is the same for every channel (shared mask,
 shared tracer), the source-plane mesh grid is channel-invariant too.
 """
-from autoarray.inversion.mesh.mesh.rectangular_adapt_density import overlay_grid_from
+from autoarray.inversion.mesh.mesh.rectangular_rtu_adapt_density import overlay_grid_from
 
 mesh_grid = overlay_grid_from(
     shape_native=mesh_shape, grid=al.Grid2DIrregular(relocated_grid)

--- a/scripts/interferometer/features/pixelization/likelihood_function.py
+++ b/scripts/interferometer/features/pixelization/likelihood_function.py
@@ -286,7 +286,7 @@ We do this by overlying a rectangular grid on the relocated traced image-plane g
 This distributes the rectangular mesh so it fully overlaps the region of the source-plane containing the traced 
 image-pixels without having edge pixels that extend beyond this region.
 """
-from autoarray.inversion.mesh.mesh.rectangular_adapt_density import overlay_grid_from
+from autoarray.inversion.mesh.mesh.rectangular_rtu_adapt_density import overlay_grid_from
 
 mesh_grid = overlay_grid_from(
     shape_native=mesh_shape, grid=al.Grid2DIrregular(relocated_grid)


### PR DESCRIPTION
## What

The autolens_workspace leg of the rectangular mesh split (PyAutoArray#462 / PyAutoGalaxy#579 / PyAutoLens#707), retiring the `RectangularAdaptDensity` / `RectangularAdaptImage` names:

- Every example moves to the `RectangularBilinearAdaptDensity` / `RectangularBilinearAdaptImage` workspace defaults — including the interferometer examples (no normal-workspace example uses RTU); RTU stays documentation-only, with the Enzi et al. 2026 citation (https://arxiv.org/abs/2606.30620).
- Prior configs: `rectangular_adapt_*.yaml` → `rectangular_rtu_adapt_*.yaml` with new `rectangular_bilinear_adapt_*.yaml` (same priors); navigator catalogue regenerated.
- `imaging/features/pixelization/modeling.py` gains an `__Advanced: RTU Rectangular Meshes__` doc-only section at the end of the script: explains the kernel-CDF transform, shows the RTU model composition as a non-executed snippet, states fast-on-GPUs-only and may-have-smoother-gradients, and cites Enzi et al.; the intro block points there.
- Three `likelihood_function` scripts imported `overlay_grid_from` by module path, which the split also renamed (`rectangular_adapt_density` → `rectangular_rtu_adapt_density`) — fixed; these were the last `rectangular_adapt_*` references in `scripts/`.

Committed notebooks intentionally lag on this branch; they regenerate through the PyAutoHands generate flow.

## Why

The library-side rename merged to the source repos' mains on 2026-08-21; until this lands, workspace `main` references retired class names that fail with `AttributeError` on current libraries (and on the next release). The sibling legs HowToLens#74 and HowToGalaxy#71 are already merged with green smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GsUfbCwPd4XC8kpsiUJp7

---
_Generated by [Claude Code](https://claude.ai/code/session_015GsUfbCwPd4XC8kpsiUJp7)_