### PR TITLE
fix: guard each tracer result read on its own file (#503)

### DIFF
--- a/notebooks/imaging/modeling.ipynb
+++ b/notebooks/imaging/modeling.ipynb
@@ -906,6 +906,7 @@
     "if (result_path / \"files\" / \"tracer.json\").exists():\n",
     "    tracer = from_json(file_path=result_path / \"files\" / \"tracer.json\")\n",
     "\n",
+    "if (result_path / \"image\" / \"tracer.fits\").exists():\n",
     "    tracer_fits = al.Array2D.from_fits(\n",
     "        file_path=result_path / \"image\" / \"tracer.fits\", hdu=0, pixel_scales=0.1\n",
     "    )"

--- a/notebooks/multi_galaxy/modeling.ipynb
+++ b/notebooks/multi_galaxy/modeling.ipynb
@@ -1050,6 +1050,7 @@
     "if (result_path / \"files\" / \"tracer.json\").exists():\n",
     "    tracer = from_json(file_path=result_path / \"files\" / \"tracer.json\")\n",
     "\n",
+    "if (result_path / \"image\" / \"tracer.fits\").exists():\n",
     "    tracer_fits = al.Array2D.from_fits(\n",
     "        file_path=result_path / \"image\" / \"tracer.fits\", hdu=0, pixel_scales=0.05\n",
     "    )"

--- a/scripts/imaging/modeling.py
+++ b/scripts/imaging/modeling.py
@@ -638,6 +638,7 @@ result_path = search.paths.output_path  # Points at the fit's unique output fold
 if (result_path / "files" / "tracer.json").exists():
     tracer = from_json(file_path=result_path / "files" / "tracer.json")
 
+if (result_path / "image" / "tracer.fits").exists():
     tracer_fits = al.Array2D.from_fits(
         file_path=result_path / "image" / "tracer.fits", hdu=0, pixel_scales=0.1
     )

--- a/scripts/multi_galaxy/modeling.py
+++ b/scripts/multi_galaxy/modeling.py
@@ -793,6 +793,7 @@ result_path = search.paths.output_path  # Points at the fit's unique output fold
 if (result_path / "files" / "tracer.json").exists():
     tracer = from_json(file_path=result_path / "files" / "tracer.json")
 
+if (result_path / "image" / "tracer.fits").exists():
     tracer_fits = al.Array2D.from_fits(
         file_path=result_path / "image" / "tracer.fits", hdu=0, pixel_scales=0.05
     )


### PR DESCRIPTION
Closes #503.

The "Loading From Output Folder" teaching section guarded on `files/tracer.json` and then, inside that branch, read `image/tracer.fits`. Under `TEST_MODE` the reduced search writes `tracer.json` but not the visualisation output `tracer.fits`, so the guard passed and the read raised `FileNotFoundError` — leaving the release smoke gate permanently red (`run_smoke_tests (3.12, autolens_workspace)`, release run 32542888112).

The block is split into two independent guards, one per file — the shape already used in `scripts/guides/results/start_here.py`, so the workspace now has a single canonical shape for this pattern:

```diff
 if (result_path / "files" / "tracer.json").exists():
     tracer = from_json(file_path=result_path / "files" / "tracer.json")
 
+if (result_path / "image" / "tracer.fits").exists():
     tracer_fits = al.Array2D.from_fits(
         file_path=result_path / "image" / "tracer.fits", hdu=0, pixel_scales=0.1
     )
```

The teaching section is otherwise untouched. `draft/maintenance/workspaces/read_through_issues.md` asks for the equivalent section to be *added* to the `group`, `cluster` and `interferometer` examples — this is the shape to propagate there.

## Scripts Changed

| Script | Change |
|--------|--------|
| `scripts/imaging/modeling.py` (638–644) | guard split; `pixel_scales=0.1` unchanged |
| `scripts/multi_galaxy/modeling.py` (793–799) | identical mismatched guard, same split; `pixel_scales=0.05` unchanged |

`multi_galaxy/modeling.py` was not named in the issue but carried the byte-identical bug and is also on `smoke_tests.txt`, so fixing only `imaging/` would have left the smoke gate red anyway.

`notebooks/imaging/modeling.ipynb` and `notebooks/multi_galaxy/modeling.ipynb` regenerated from the changed scripts via PyAutoHands `generate.py` — only the two guard cells changed, with no catalogue (`llms-full.txt`, `workspace_index.json`) or unrelated notebook drift.

## API Changes

None. Workspace scripts and their notebook mirrors only; no library source touched.

## Validation

Reproduced the failure before fixing it. The smoke profile's default `PYAUTO_TEST_MODE=2` bypasses the sampler and writes no `tracer.json` at all, so the guard is never entered and the bug does not surface there; `PYAUTO_TEST_MODE=1` (reduced search) is the mode that writes `tracer.json` but not `tracer.fits`. Under `config/build/profile_smoke.yaml` defaults with `PYAUTO_TEST_MODE=1`:

| Script | Before | After |
|--------|--------|-------|
| `imaging/modeling.py` | exit **1** — `FileNotFoundError: .../modeling/18fbb5f4.../image/tracer.fits` at line 641 | exit **0** |
| `multi_galaxy/modeling.py` | exit **1** — same error at `.../multi_galaxy/simple/modeling/bce8a3b4.../image/tracer.fits` | exit **0** |

Also green: `PYAUTO_TEST_MODE=2` (the smoke default) on `imaging/modeling.py`; `scripts/check_sizes.sh`; `check_navigator.py --root .` ("every scripts/ and notebooks/ reference resolves"); `python -m py_compile` on both scripts.

The full-fidelity path is unaffected by construction — the split guard is strictly weaker than the one it replaces, so a real fit that writes `tracer.fits` still enters the same branch. That is consistent with Heart's Stage 3 `run_scripts (3.12, autolens, imaging)` having been green (672p/0f) throughout.

## Validation checklist

- [x] **Tests** — n/a, stated: `autolens_workspace` has no test directory; it is validated by the smoke gate.
- [x] **Smoke** — the two affected `smoke_tests.txt` entries run under the smoke profile, reproduced-then-fixed as tabled above. `.github/scripts/run_smoke.py` itself was not used: this is a `web-github` session and the runner needs a sibling PyAutoHands checkout on `PYTHONPATH`, so the profile env was applied directly. CI runs the real gate on this PR.
- [x] **Review** — no review-faculty pass; this is a two-line guard change reviewed against the canonical shape in `guides/results/start_here.py`.
- [ ] **Heart** — **NOT EVALUATED**: `pyauto-heart` is unreachable from this session, so no readiness verdict was obtained. Flagged rather than assumed.

## Autonomy

Issue #503 ran under `--auto` at effective level `supervised` (prompt header `safe`, `bug` work-type cap `supervised`). It parked at ship sign-off as the contract requires; this PR is open on the human sign-off given in-session. Merge remains a human act.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uqp3r62nPhBVS8T1Hz3N1n)_