### PR TITLE
docs: imaging pixelization fit.py CPU Users paragraph was the interferometer text (#506)

### DIFF
--- a/scripts/imaging/features/pixelization/fit.py
+++ b/scripts/imaging/features/pixelization/fit.py
@@ -19,14 +19,14 @@ Pixelizations are covered in detail in chapter 3 of the **HowToLens** lectures.
 
 __CPU Users__
 
-Matrices must be set up for a pixelized source reconstruction which speed up the linear algebra. On GPU, this takes
-seconds, or at most a minute for datasets with tens of millions, or more visibities. On CPU, this can be a lot slower,
-taking over hours. If you are on CPU,  the `features/pixelization/many_visibilities_preparation` explains how this
-initial setup can be performed before lens modeling and saved to hard disk for fast loading before the model fit.
+On CPU, the linear algebra of a pixelized source reconstruction is fastest via the sparse operator formalism, which
+is set up once with `dataset.apply_sparse_operator_cpu()`. This set up takes a few seconds to a few minutes depending
+on the dataset size, after which every fit is substantially faster. The `features/pixelization/cpu_fast_modeling`
+example shows the full CPU set up.
 
 __Contents__
 
-- **CPU Users:** Matrices must be set up for a pixelized source reconstruction which speed up the linear algebra.
+- **CPU Users:** On CPU, the sparse operator formalism set up by `dataset.apply_sparse_operator_cpu()` makes every fit substantially faster.
 - **Advantages & Disadvantages:** Many strongly lensed source galaxies are complex, and have asymmetric and irregular morphologies.
 - **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
 - **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.


### PR DESCRIPTION
## Summary

The `__CPU Users__` docstring block in `scripts/imaging/features/pixelization/fit.py` was the
*interferometer* paragraph: it talked about visibilities, set up "taking over hours", and pointed at
`features/pixelization/many_visibilities_preparation`, which exists only under
`scripts/interferometer/` — so an imaging reader following it hit a dead link and misleading advice.

It is replaced with the imaging-correct guidance: on CPU the linear algebra of a pixelized source
reconstruction is fastest via the sparse operator formalism set up once with
`dataset.apply_sparse_operator_cpu()`, and `features/pixelization/cpu_fast_modeling` (which does
exist in this directory) shows the full CPU set up. The matching `__Contents__` bullet is updated to
a one-line summary of the same.

Prose only — no code or behaviour change.

## Scripts Changed

- `scripts/imaging/features/pixelization/fit.py` — `__CPU Users__` docstring paragraph rewritten
  (interferometer text → imaging sparse-operator CPU guidance), and the `- **CPU Users:**`
  `__Contents__` bullet updated to match.

## Test Plan

- `python -c "import ast; ast.parse(open(...).read())"` on the edited script — parses.
- Smoke run via the workspace runner
  (`PyAutoHands/autohands/run_python.py autolens_workspace scripts --list <one-entry list>
  --env-config config/build/profile_smoke.yaml`) — `PASS (12.6s)`.
- Notebooks not regenerated (docstring-only change; notebook generation deliberately not run in this
  session).

Library PR: https://github.com/PyAutoLabs/PyAutoArray/pull/504 (comment-only, no gate dependency). Closes #506.

Generated by the PyAutoLabs agent workflow.
