### PR TITLE
Guard aggregator sample-instance guides against SamplesException

### DIFF
--- a/notebooks/guides/results/aggregator/samples.ipynb
+++ b/notebooks/guides/results/aggregator/samples.ipynb
@@ -555,17 +555,24 @@
     "\n",
     "A non-linear search retains every model that is accepted during the model-fit.\n",
     "\n",
-    "We can create an instance of any model -- below we create an instance of the last accepted model."
+    "We can create an instance of any model -- below we create an instance of the last accepted model.\n",
+    "\n",
+    "A stored sample is not guaranteed to be reconstructable as an instance. A non-linear search evaluates parameter\n",
+    "values that the model's own validation later rejects (for example an `ell_comps` magnitude of 1.0 or greater), and\n",
+    "those points are still written to `samples.csv`. Materializing one raises an `af.exc.SamplesException`, whose\n",
+    "documented recovery is to ask for the raw parameter values instead by passing `as_instance=False`."
    ]
   },
   {
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "instance = samples.from_sample_index(sample_index=-1)\n",
+    "try:\n",
+    "    instance = samples.from_sample_index(sample_index=-1)\n",
     "\n",
-    "print(instance.galaxies.lens.mass)\n",
-    "print(instance.galaxies.lens.mass)"
+    "    print(instance.galaxies.lens.mass)\n",
+    "except af.exc.SamplesException:\n",
+    "    print(samples.from_sample_index(sample_index=-1, as_instance=False))"
    ],
    "outputs": [],
    "execution_count": null

--- a/notebooks/guides/results/aggregator/samples_via_aggregator.ipynb
+++ b/notebooks/guides/results/aggregator/samples_via_aggregator.ipynb
@@ -583,7 +583,12 @@
     "\n",
     "A non-linear search retains every model that is accepted during the model-fit.\n",
     "\n",
-    "We can create an instance of any model -- below we create an instance of the last accepted model."
+    "We can create an instance of any model -- below we create an instance of the last accepted model.\n",
+    "\n",
+    "A stored sample is not guaranteed to be reconstructable as an instance. A non-linear search evaluates parameter\n",
+    "values that the model's own validation later rejects (for example an `ell_comps` magnitude of 1.0 or greater), and\n",
+    "those points are still written to `samples.csv`. Materializing one raises an `af.exc.SamplesException`, whose\n",
+    "documented recovery is to ask for the raw parameter values instead by passing `as_instance=False`."
    ]
   },
   {
@@ -591,9 +596,12 @@
    "metadata": {},
    "source": [
     "for samples in agg.values(\"samples\"):\n",
-    "    instance = samples.from_sample_index(sample_index=-1)\n",
+    "    try:\n",
+    "        instance = samples.from_sample_index(sample_index=-1)\n",
     "\n",
-    "    print(instance.galaxies.source.bulge)"
+    "        print(instance.galaxies.source.bulge)\n",
+    "    except af.exc.SamplesException:\n",
+    "        print(samples.from_sample_index(sample_index=-1, as_instance=False))"
    ],
    "outputs": [],
    "execution_count": null

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -326,11 +326,18 @@ __Sample Instance__
 A non-linear search retains every model that is accepted during the model-fit.
 
 We can create an instance of any model -- below we create an instance of the last accepted model.
-"""
-instance = samples.from_sample_index(sample_index=-1)
 
-print(instance.galaxies.lens.mass)
-print(instance.galaxies.lens.mass)
+A stored sample is not guaranteed to be reconstructable as an instance. A non-linear search evaluates parameter
+values that the model's own validation later rejects (for example an `ell_comps` magnitude of 1.0 or greater), and
+those points are still written to `samples.csv`. Materializing one raises an `af.exc.SamplesException`, whose
+documented recovery is to ask for the raw parameter values instead by passing `as_instance=False`.
+"""
+try:
+    instance = samples.from_sample_index(sample_index=-1)
+
+    print(instance.galaxies.lens.mass)
+except af.exc.SamplesException:
+    print(samples.from_sample_index(sample_index=-1, as_instance=False))
 
 """
 __Search Plots__

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -354,11 +354,19 @@ __Sample Instance__
 A non-linear search retains every model that is accepted during the model-fit.
 
 We can create an instance of any model -- below we create an instance of the last accepted model.
+
+A stored sample is not guaranteed to be reconstructable as an instance. A non-linear search evaluates parameter
+values that the model's own validation later rejects (for example an `ell_comps` magnitude of 1.0 or greater), and
+those points are still written to `samples.csv`. Materializing one raises an `af.exc.SamplesException`, whose
+documented recovery is to ask for the raw parameter values instead by passing `as_instance=False`.
 """
 for samples in agg.values("samples"):
-    instance = samples.from_sample_index(sample_index=-1)
+    try:
+        instance = samples.from_sample_index(sample_index=-1)
 
-    print(instance.galaxies.source.bulge)
+        print(instance.galaxies.source.bulge)
+    except af.exc.SamplesException:
+        print(samples.from_sample_index(sample_index=-1, as_instance=False))
 
 """
 __Search Plots__


### PR DESCRIPTION
The two aggregator sample-instance guides assumed every stored sample can be materialized as a model instance. A non-linear search can accept parameter values the model's own validation later rejects (e.g. an `ell_comps` magnitude >= 1.0), and those points are still written to `samples.csv` — so `samples.from_sample_index(sample_index=-1)` can raise `af.exc.SamplesException`.

Both guides now explain this and wrap the call in try/except, falling back to the raw parameter values via `as_instance=False`.

Scripts touched:
- `scripts/guides/results/aggregator/samples.py`
- `scripts/guides/results/aggregator/samples_via_aggregator.py`

Notebooks regenerated with PyAutoHands `generate.py` and committed alongside (catalogue files unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)