### PR TITLE
docs: SLaM mass_light_dark — note the fixed-geometry deflection memo and its kill switch (memo phase 3, #528)

### DIFF
--- a/notebooks/imaging/features/advanced/mass_stellar_dark/slam.ipynb
+++ b/notebooks/imaging/features/advanced/mass_stellar_dark/slam.ipynb
@@ -433,7 +433,13 @@
     "\n",
     "The lens bulge is modeled as a `LightMassProfile` (`al.lmp.Sersic`) whose parameters are initialized from the\n",
     "LIGHT LP PIPELINE result via `al.util.chaining.mass_light_dark_from`. The dark matter halo (`NFWMCRLudlow`) centre\n",
-    "is aligned with the stellar bulge centre."
+    "is aligned with the stellar bulge centre.\n",
+    "\n",
+    "The light-tied mass profiles take their geometry from the fixed light model, so their deflection angles depend\n",
+    "only on parameters which do not vary over the fit. On the numpy path these fields are therefore memoised across\n",
+    "likelihood evaluations, and for an MGE lens light (a `Basis` of Gaussians) each fixed Gaussian's field is computed\n",
+    "once and rescaled by the free `mass_to_light_ratio` on every evaluation after it (on JAX the same field is folded\n",
+    "out of the traced graph as a constant). Set `AUTOGALAXY_DEFLECTIONS_MEMO=0` to disable this."
    ]
   },
   {

--- a/scripts/imaging/features/advanced/mass_stellar_dark/slam.py
+++ b/scripts/imaging/features/advanced/mass_stellar_dark/slam.py
@@ -341,6 +341,12 @@ separate dark matter halo is included.
 The lens bulge is modeled as a `LightMassProfile` (`al.lmp.Sersic`) whose parameters are initialized from the
 LIGHT LP PIPELINE result via `al.util.chaining.mass_light_dark_from`. The dark matter halo (`NFWMCRLudlow`) centre
 is aligned with the stellar bulge centre.
+
+The light-tied mass profiles take their geometry from the fixed light model, so their deflection angles depend
+only on parameters which do not vary over the fit. On the numpy path these fields are therefore memoised across
+likelihood evaluations, and for an MGE lens light (a `Basis` of Gaussians) each fixed Gaussian's field is computed
+once and rescaled by the free `mass_to_light_ratio` on every evaluation after it (on JAX the same field is folded
+out of the traced graph as a constant). Set `AUTOGALAXY_DEFLECTIONS_MEMO=0` to disable this.
 """
 
 


### PR DESCRIPTION
## Summary
Closes #528 — phase 3 (downstream sweep) of the `gaussian-deflections-precompute` epic. Phases 1 and 2 are merged (PyAutoGalaxy#602/#605, PyAutoArray#520, autolens_profiling#214/#216); this phase adds no mechanism. It verifies the memo on the driver it was built for and tells the user the switch exists.

**Doc**: one paragraph in the `mass_light_dark` pipeline docstring of `scripts/imaging/features/advanced/mass_stellar_dark/slam.py` — the light-tied mass profiles' deflections depend only on the fixed light geometry, so they are memoised across likelihood evaluations on the numpy path; for an MGE lens light (a `Basis` of Gaussians) each fixed Gaussian's field is computed once and rescaled by the free `mass_to_light_ratio` (on JAX the field is folded out of the traced graph as a constant); `AUTOGALAXY_DEFLECTIONS_MEMO=0` disables it. The `multi_galaxy` and `group` SLaM variants do not carry this docstring block and were left alone. Notebook regenerated with the workspace generator; the paragraph is markdown cell 12; no other notebook changed.

**Sweep on the merged library mains (PyAutoGalaxy `65af1122`, PyAutoArray `e36a5af4`)**, all outputs to scratch, `OMP_NUM_THREADS=1`:
- `test_autolens` — 610 passed, 1 xfailed.
- SLaM `slam.py` in test mode (smoke defaults, `PYAUTO_TEST_MODE=2`, `PYAUTO_SMALL_DATASETS=1`), 3 repeats per leg: every stage's max-log-likelihood **bit-identical** memo on vs off; `mass_light_dark[1]` median 0.370 s on vs 0.515 s off (0.72×), every stage at or below memo-off; `memo_stats` 119 hits / 20 misses / 0 evictions / 119 kB / 20 entries; kill-switch leg all zeros. The linear-Sersic light + free ratio (an L1 profile whose key changes every call) showed no store-churn penalty at this scale — negative finding, no library change proposed. Test mode calls the likelihood once per stage, so these are smoke-scale ratios; the production-scale number for this shape is autolens_profiling's `pixelization_numba_mge_mass` cell (2.61× per call at hst resolution, re-run here).
- autolens_workspace_test: `imaging/jax_likelihood/mge.py` PASS (vmap −86283.10390232 vs pin −86283.10392994, 3.2e-10; `jit(fit_from)` matches numpy to 1e-15), `imaging/jax_grad/mge.py` PASS (FD max rel 2.6e-6), `imaging/visualization/modeling_visualization_jit.py` PASS (35 min, all asserts), `interferometer/visualization/modeling_visualization_jit.py` Part 1 PASS then OOM-killed in its live-Nautilus Part 2 at 10.7 GB RSS — exactly its existing `no_run.yaml` SLOW/OOM entry, unrelated to the memo. No pin edited.
- Numba likelihood pins: `pixelization_numba` hst 27661.910206968903 vs pin 27661.910133665442 (rel 2.65e-9, within 1e-6); `pixelization_numba_mge_mass` −56107.564075886374 bit-identical, memo 2.61×.

## Scripts Changed
- `scripts/imaging/features/advanced/mass_stellar_dark/slam.py` — one docstring paragraph in the `mass_light_dark` pipeline prose (memo behaviour + `AUTOGALAXY_DEFLECTIONS_MEMO=0`)
- `notebooks/imaging/features/advanced/mass_stellar_dark/slam.ipynb` — regenerated from the script (markdown cell 12)

## Upstream PR
- PyAutoGalaxy#602 and #605, PyAutoArray#520 (merged, pending-release) — the mechanism this documents; library-first gate satisfied

## Test Plan
- [x] `test_autolens` 610 passed on the merged mains
- [x] SLaM `mass_stellar_dark/slam.py` test-mode run completes with the memo on and with `AUTOGALAXY_DEFLECTIONS_MEMO=0`; stage likelihoods bit-identical; runtimes recorded
- [x] autolens_workspace_test MGE regression scripts pass, pins unchanged
- [x] numba likelihood pins held at rtol 1e-6
- [x] notebook regenerated; paragraph renders as a markdown cell; `ruff format --check` clean on the script (one pre-existing F401 on `main`)

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhnA4pFN2NycuKc8Ni6s2R
