### PR TITLE
docs: drop "also"; AI Assistant note names the paid conversation-assistant routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Welcome to the **PyAutoLens** Workspace!
 
 ### Human-Readable Documentation and Examples
 
-The following human-readable documentation and examples are also useful for new starters:
+The following human-readable documentation and examples are useful for new starters:
 
 - [Installation guide](https://pyautolens.readthedocs.io/): set up **PyAutoLens** on your personal computer.
 - [PyAutoLens on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.8.29.1/start_here.ipynb): try **PyAutoLens** in a web browser without installing it.
@@ -25,7 +25,7 @@ The following human-readable documentation and examples are also useful for new 
 
 The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
 
-**The PyAutoLens AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
+**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
 
 ## New Users
 

--- a/markdown/start_here.md
+++ b/markdown/start_here.md
@@ -781,4 +781,4 @@ ChatGPT and coding agents such as Claude Code and Codex. You can get started sim
 gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the
 [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
 
-**The PyAutoLens AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
+**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**

--- a/start_here.ipynb
+++ b/start_here.ipynb
@@ -808,7 +808,7 @@
         "gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the\n",
         "[autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.\n",
         "\n",
-        "**The PyAutoLens AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**"
+        "**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**"
       ]
     }
   ],

--- a/start_here.py
+++ b/start_here.py
@@ -671,6 +671,6 @@ ChatGPT and coding agents such as Claude Code and Codex. You can get started sim
 gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the
 [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
 
-**The PyAutoLens AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
+**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
 
 """


### PR DESCRIPTION
## Summary
Follow-up to #529 / PyAutoLabs/autolens_assistant#120. Two wording fixes, no reordering: the README's human-readable-docs lead sentence drops its now-redundant "also", and the bold AI Assistant note (README and the closing block of `start_here.py`) no longer says conversation agents are unsupported — it now reads: **"The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested."**

Part of PyAutoLabs/autolens_assistant#122 (six-repo docs change, PR-open only under a recorded Heart-RED ack — merge is a human decision).

## Scripts Changed
None functionally — docstring prose only. Files touched:
- `README.md`
- `start_here.py` (module docstring, closing AI Assistant block)
- `start_here.ipynb` (regenerated)
- `markdown/start_here.md` (prose line mirrored)

## Notebooks
`start_here.ipynb` was regenerated from `start_here.py` via the same `build_util.py_to_notebook` + `inject_colab_setup` path `generate.py` uses for a root script, run from inside the workspace; it differs from `main` by exactly the one prose line. `markdown/start_here.md` was not re-rendered (`generate_markdown.py` executes the scripts, and `--only start_here.py` also selects `scripts/imaging/start_here.py`); the identical one-line substitution was applied to the twin, which is what the renderer copies verbatim from the docstring.

## Upstream PR
PyAutoLabs/PyAutoLens PR from the same branch (`feature/docs-followup-paid-plan-assistants`) — docs only, no API dependency.

## Test Plan
- [x] Witness greps return nothing in this repo
- [ ] Smoke / navigator CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vwajqh36GQMzDcpTRoF5Qj