### PR TITLE
docs: agentic-only wording for the AI Assistant block

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ The following human-readable documentation and examples are useful for new start
 
 ### PyAutoLens AI Assistant
 
-The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
+The [**PyAutoLens AI Assistant**](https://github.com/PyAutoLabs/autolens_assistant) lets you do gravitational lensing science in natural language from inside an AI coding agent. You can get started simply by asking it a question about gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
 
-**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
+**The assistant runs inside an AI coding agent: Claude Code or Codex are recommended. Sustained scientific use normally needs paid access to one of them (a personal subscription, institutional access or API billing). OpenCode is an experimental alternative whose client is free but whose model access, cost and capability depend on the provider. Browser chat routes (ChatGPT or Claude with a GitHub connector) are no longer supported.**
 
 ## New Users
 

--- a/markdown/start_here.md
+++ b/markdown/start_here.md
@@ -776,9 +776,9 @@ Checkout `autolens_workspace/*/weak/start_here.py` to fit your first weak lensin
 
 __PyAutoLens AI Assistant__
 
-The [PyAutoLens AI Assistant](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as
-ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about
+The [PyAutoLens AI Assistant](https://github.com/PyAutoLabs/autolens_assistant) lets you do gravitational lensing
+science in natural language from inside an AI coding agent. You can get started simply by asking it a question about
 gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the
 [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
 
-**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
+**The assistant runs inside an AI coding agent: Claude Code or Codex are recommended. Sustained scientific use normally needs paid access to one of them (a personal subscription, institutional access or API billing). OpenCode is an experimental alternative whose client is free but whose model access, cost and capability depend on the provider. Browser chat routes (ChatGPT or Claude with a GitHub connector) are no longer supported.**

--- a/start_here.ipynb
+++ b/start_here.ipynb
@@ -803,12 +803,12 @@
         "\n",
         "__PyAutoLens AI Assistant__\n",
         "\n",
-        "The [PyAutoLens AI Assistant](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as\n",
-        "ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about\n",
+        "The [PyAutoLens AI Assistant](https://github.com/PyAutoLabs/autolens_assistant) lets you do gravitational lensing\n",
+        "science in natural language from inside an AI coding agent. You can get started simply by asking it a question about\n",
         "gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the\n",
         "[autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.\n",
         "\n",
-        "**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**"
+        "**The assistant runs inside an AI coding agent: Claude Code or Codex are recommended. Sustained scientific use normally needs paid access to one of them (a personal subscription, institutional access or API billing). OpenCode is an experimental alternative whose client is free but whose model access, cost and capability depend on the provider. Browser chat routes (ChatGPT or Claude with a GitHub connector) are no longer supported.**"
       ]
     }
   ],

--- a/start_here.py
+++ b/start_here.py
@@ -666,11 +666,11 @@ Checkout `autolens_workspace/*/weak/start_here.py` to fit your first weak lensin
 
 __PyAutoLens AI Assistant__
 
-The [PyAutoLens AI Assistant](https://github.com/PyAutoLabs/autolens_assistant) supports conversation agents such as
-ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about
+The [PyAutoLens AI Assistant](https://github.com/PyAutoLabs/autolens_assistant) lets you do gravitational lensing
+science in natural language from inside an AI coding agent. You can get started simply by asking it a question about
 gravitational lensing or describing the task you would like to perform with **PyAutoLens**. See the
 [autolens_assistant GitHub page](https://github.com/PyAutoLabs/autolens_assistant) for its full scope and instructions.
 
-**The PyAutoLens AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
+**The assistant runs inside an AI coding agent: Claude Code or Codex are recommended. Sustained scientific use normally needs paid access to one of them (a personal subscription, institutional access or API billing). OpenCode is an experimental alternative whose client is free but whose model access, cost and capability depend on the provider. Browser chat routes (ChatGPT or Claude with a GitHub connector) are no longer supported.**
 
 """


### PR DESCRIPTION
## Summary

Docs only; no library dependency. The AI Assistant block in `README.md` and `start_here.py` (with the regenerated `start_here.ipynb` and `markdown/start_here.md` mirrors) no longer says the assistant supports conversation agents such as ChatGPT or requires a paid subscription. It states the agentic-only policy adopted in PyAutoLabs/autolens_assistant (Claude Code or Codex recommended; paid access via subscription, institutional access or API billing; OpenCode experimental; browser-chat routes no longer supported).

Scripts touched: `start_here.py` only (one docstring block). Notebook regenerated through PyAutoHands `build_util.py_to_notebook`; only the assistant markdown cell changed. Nothing under `scripts/` or `notebooks/` changed.

## Test plan

- [ ] CI: smoke, navigator, url check, size guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsLuCV9nbPPUWBK9rewCZe

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsLuCV9nbPPUWBK9rewCZe)_